### PR TITLE
fix: duplicate item_id_getter in dashboard/users/user/dialog

### DIFF
--- a/src/bot/routers/dashboard/users/user/dialog.py
+++ b/src/bot/routers/dashboard/users/user/dialog.py
@@ -424,7 +424,6 @@ devices_list = Window(
             ),
         ),
         id="devices_list",
-        item_id_getter=lambda item: item["hwid"],
         item_id_getter=lambda item: item["short_hwid"],
         items="devices",
     ),


### PR DESCRIPTION
```
item_id_getter=lambda item: item["hwid"],
item_id_getter=lambda item: item["short_hwid"],
```
was in `src/bot/routers/dashboard/users/user/dialog.py`