### PR TITLE
Adds docker-compose.yml variant, where reverse proxy not like Docker container

### DIFF
--- a/docker-compose.prod.external.reversenotindocker.yml
+++ b/docker-compose.prod.external.reversenotindocker.yml
@@ -1,0 +1,122 @@
+services:
+  remnashop-db:
+    image: postgres:17
+    container_name: "remnashop-db"
+    hostname: remnashop-db
+    restart: unless-stopped
+
+    env_file:
+      - .env
+    environment:
+      - POSTGRES_USER=${DATABASE_USER}
+      - POSTGRES_PASSWORD=${DATABASE_PASSWORD}
+      - POSTGRES_DB=${DATABASE_NAME}
+      - TZ=UTC
+    
+    volumes:
+      - remnashop-db-data:/var/lib/postgresql/data
+
+    networks:
+      - remnawave-network
+
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 3s
+      timeout: 10s
+      retries: 3
+    
+
+  remnashop-redis:
+    image: valkey/valkey:9-alpine
+    container_name: "remnashop-redis"
+    hostname: remnashop-redis
+    restart: unless-stopped
+
+    command: [ "--requirepass", "${REDIS_PASSWORD}" ]
+
+    volumes:
+      - remnashop-redis-data:/data
+
+    networks:
+      - remnawave-network
+
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 3s
+      timeout: 10s
+      retries: 3
+    
+
+  remnashop:
+    &remnashop
+    image: ghcr.io/snoups/remnashop:latest
+    container_name: "remnashop"
+    hostname: remnashop
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:5000:5000"
+    env_file:
+      - .env
+    environment:
+      RESET_ASSETS: "${RESET_ASSETS:-false}"
+
+    depends_on:
+        remnashop-db:
+          condition: service_healthy
+        remnashop-redis:
+          condition: service_healthy
+
+    volumes:
+      - ./logs:/opt/remnashop/logs
+      - ./assets:/opt/remnashop/assets
+
+    networks:
+      - remnawave-network
+    
+
+  remnashop-taskiq-worker:
+    <<: *remnashop
+    container_name: "remnashop-taskiq-worker"
+    hostname: remnashop-taskiq-worker
+    ports: []
+    command: taskiq worker src.infrastructure.taskiq.worker:worker 
+      --tasks-pattern src/infrastructure/taskiq/tasks -fsd
+
+    depends_on:
+        remnashop-redis:
+          condition: service_healthy
+        remnashop-db:
+          condition: service_healthy
+
+
+  remnashop-taskiq-scheduler:
+    <<: *remnashop
+    container_name: "remnashop-taskiq-scheduler"
+    hostname: remnashop-taskiq-scheduler
+    ports: []
+    command: taskiq scheduler src.infrastructure.taskiq.scheduler:scheduler
+      --tasks-pattern src/infrastructure/taskiq/tasks -fsd
+
+    depends_on:
+        remnashop-redis:
+          condition: service_healthy
+        remnashop-db:
+          condition: service_healthy
+
+
+networks:
+  remnawave-network:
+    name: remnawave-network 
+    driver: bridge 
+    external: false
+
+volumes:
+  remnashop-db-data:
+    name: remnashop-db-data
+    driver: local
+    external: false
+    
+  remnashop-redis-data:
+    name: remnashop-redis-data
+    driver: local
+    external: false


### PR DESCRIPTION
Всем столкнувшимся с 502 ошибкой вебхука - посвящается.

Прокидываем порт к внешнему сервису реверса (реверс не в докере) + сбрасываем порты у воркера и планировщика