### PR TITLE
Add Cloudlfare Zero Trust support for panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,6 +102,10 @@ REMNAWAVE_CADDY_TOKEN=
 # Must be in the format 'name=value' (e.g., wDpdagIh=T4yWkD8rM1oF).
 REMNAWAVE_COOKIE=
 
+# If you use Cloudflare Zero Trust to protect your panel, please use this variables to bypass the security.
+REMNAWAVE_CF_CLIENT_ID=
+REMNAWAVE_CF_CLIENT_SECRET=
+
 
 # - - - - - DATABASE CONFIGURATION - - - - - #
 

--- a/src/core/config/remnawave.py
+++ b/src/core/config/remnawave.py
@@ -15,6 +15,8 @@ class RemnawaveConfig(BaseConfig, env_prefix="REMNAWAVE_"):
     port: int = 3000
     token: SecretStr
     caddy_token: SecretStr = SecretStr("")
+    cf_client_id: SecretStr = SecretStr("")
+    cf_client_secret: SecretStr = SecretStr("")
     webhook_secret: SecretStr
     cookie: SecretStr = SecretStr("")
 

--- a/src/infrastructure/di/providers/remnawave.py
+++ b/src/infrastructure/di/providers/remnawave.py
@@ -16,6 +16,8 @@ class RemnawaveProvider(Provider):
         headers = {}
         headers["Authorization"] = f"Bearer {config.remnawave.token.get_secret_value()}"
         headers["X-Api-Key"] = config.remnawave.caddy_token.get_secret_value()
+        headers["CF-Access-Client-Id"] = config.remnawave.cf_client_id.get_secret_value()
+        headers["CF-Access-Client-Secret"] = config.remnawave.cf_client_secret.get_secret_value()
 
         if not config.remnawave.is_external:
             headers["x-forwarded-proto"] = "https"


### PR DESCRIPTION
Bot can now access the Cloudflare Zero Trust protected Remnawave panel: https://docs.rw/docs/security/cloudflare-zero-trust