### PR TITLE
feat: backup connection button when the mini app is active

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,10 @@ BOT_SUPPORT_USERNAME=change_me
 #   https://github.com/maposia/remnawave-telegram-sub-mini-app
 BOT_MINI_APP=false
 
+# Show a fallback "connect" button (opens subscription page in browser) when Mini App is active.
+# Useful in regions where Telegram Mini Apps may be unavailable due to blocks.
+BOT_MINI_APP_RESERVE=false
+
 # Hostname or Docker service name for connecting to the Remnawave API.
 REMNAWAVE_HOST=remnawave
 

--- a/assets/translations/ru/buttons.ftl
+++ b/assets/translations/ru/buttons.ftl
@@ -42,6 +42,7 @@ btn-requirement =
 btn-menu =
     .trial = 🎁 ПОПРОБОВАТЬ БЕСПЛАТНО
     .connect = 🚀 Подключиться
+    .connect-reserve = 🔗 Подключиться (резерв)
     .devices = 📱 Устройства
     .subscription = 💳 Подписка
     .invite = 👥 Пригласить

--- a/src/core/config/bot.py
+++ b/src/core/config/bot.py
@@ -15,6 +15,7 @@ class BotConfig(BaseConfig, env_prefix="BOT_"):
     owner_id: int
     support_username: SecretStr
     mini_app: Union[bool, SecretStr] = False
+    mini_app_reserve: bool = False
     proxy_url: Optional[SecretStr] = None
 
     reset_webhook: bool = False
@@ -31,6 +32,10 @@ class BotConfig(BaseConfig, env_prefix="BOT_"):
         if isinstance(self.mini_app, bool):
             return self.mini_app
         return bool(self.mini_app_url)
+
+    @property
+    def is_mini_app_reserve(self) -> bool:
+        return self.is_mini_app and self.mini_app_reserve
 
     @property
     def mini_app_url(self) -> Union[bool, str]:

--- a/src/telegram/keyboards.py
+++ b/src/telegram/keyboards.py
@@ -60,6 +60,12 @@ connect_buttons = (
         style=Style(ButtonStyle.PRIMARY),
     ),
     Url(
+        text=I18nFormat("btn-menu.connect-reserve"),
+        url=Format("{subscription_url}"),
+        id="connect_reserve",
+        when=F["is_mini_app_reserve"] & F["connectable"],
+    ),
+    Url(
         text=I18nFormat("btn-menu.connect"),
         url=Format("{connection_url}"),
         id="connect_sub_page",

--- a/src/telegram/routers/menu/dialog.py
+++ b/src/telegram/routers/menu/dialog.py
@@ -47,15 +47,14 @@ from .handlers import (
 menu = Window(
     Banner(BannerName.MENU),
     I18nFormat("msg-main-menu"),
+    *connect_buttons,
     Row(
-        *connect_buttons,
         Button(
             text=I18nFormat("btn-menu.connect-not-available"),
             id="not_available",
             on_click=show_reason,
-            when=~F["connectable"],
         ),
-        when=F["has_subscription"],
+        when=F["has_subscription"] & ~F["connectable"],
     ),
     Row(
         Button(

--- a/src/telegram/routers/menu/getters.py
+++ b/src/telegram/routers/menu/getters.py
@@ -49,6 +49,7 @@ async def menu_getter(
             "show_purchase_discount": show_purchase_discount,
             # ui / config
             "is_mini_app": config.bot.is_mini_app,
+            "is_mini_app_reserve": config.bot.is_mini_app_reserve,
             "support_url": support_url,
             # referral
             "referral_enabled": menu_data.is_referral_enabled,
@@ -66,6 +67,7 @@ async def menu_getter(
             "expire_time": None,
             "reset_time": None,
             "connection_url": None,
+            "subscription_url": None,
             "row_1_buttons": [b for b in menu_data.custom_buttons if b.index in (1, 2)],
             "row_2_buttons": [b for b in menu_data.custom_buttons if b.index in (3, 4)],
             "row_3_buttons": [b for b in menu_data.custom_buttons if b.index in (5, 6)],
@@ -103,6 +105,7 @@ async def menu_getter(
                 "connection_url": config.bot.mini_app_url
                 if isinstance(config.bot.mini_app_url, str)
                 else subscription.url,
+                "subscription_url": subscription.url,
             }
         )
         logger.debug(f"Menu data for user {user.telegram_id}: {data}")

--- a/src/telegram/routers/subscription/dialog.py
+++ b/src/telegram/routers/subscription/dialog.py
@@ -238,9 +238,7 @@ confirm = Window(
 success_payment = Window(
     Banner(BannerName.SUBSCRIPTION),
     I18nFormat("msg-subscription-success"),
-    Row(
-        *connect_buttons,
-    ),
+    *connect_buttons,
     *back_main_menu_button,
     IgnoreUpdate(),
     state=Subscription.SUCCESS,
@@ -250,9 +248,7 @@ success_payment = Window(
 success_trial = Window(
     Banner(BannerName.SUBSCRIPTION),
     I18nFormat("msg-subscription-trial"),
-    Row(
-        *connect_buttons,
-    ),
+    *connect_buttons,
     *back_main_menu_button,
     IgnoreUpdate(),
     state=Subscription.TRIAL,

--- a/src/telegram/routers/subscription/getters.py
+++ b/src/telegram/routers/subscription/getters.py
@@ -290,7 +290,9 @@ async def getter_connect(
 
     return {
         "is_mini_app": config.bot.is_mini_app,
+        "is_mini_app_reserve": config.bot.is_mini_app_reserve,
         "connection_url": config.bot.mini_app_url or current_subscription.url,
+        "subscription_url": current_subscription.url,
         "connectable": True,
     }
 
@@ -318,6 +320,8 @@ async def success_payment_getter(
         "expire_time": i18n_format_expire_time(subscription.expire_at),
         "added_duration": i18n_format_days(subscription.plan_snapshot.duration),
         "is_mini_app": config.bot.is_mini_app,
+        "is_mini_app_reserve": config.bot.is_mini_app_reserve,
         "connection_url": config.bot.mini_app_url or subscription.url,
+        "subscription_url": subscription.url,
         "connectable": True,
     }


### PR DESCRIPTION
# feat: резервная кнопка подключения при активном Mini App

<img width="1313" height="1096" alt="IMG_3871" src="https://github.com/user-attachments/assets/06c589b8-0c24-416a-9dbc-9bf2b26d1213" />

## Зачем

Когда `BOT_MINI_APP` задаёт URL мини-приложения, кнопка «Подключиться» открывает Telegram Mini App. В регионах с ограничениями (РКН, блокировки доменов и т.п.) Mini App может быть недоступен, и пользователь оказывается в тупике — нажал кнопку, ничего не открылось, обходных путей в интерфейсе нет.

PR добавляет **резервную** кнопку подключения, которая открывает страницу подписки в браузере (как при отключённом Mini App). Кнопка показывается под основной и включается отдельным флагом — оператор бота сам решает, нужен ли ему «двойной» интерфейс.

## Как это работает

| `BOT_MINI_APP` | `BOT_MINI_APP_RESERVE` | Что видит пользователь |
| --- | --- | --- |
| `false` | — | Одна кнопка `🚀 Подключиться` (Url, открывает subscription page) — **поведение не изменилось** |
| `true` / URL | `false` (по умолчанию) | Одна кнопка `🚀 Подключиться` (WebApp, открывает Mini App) — **поведение не изменилось** |
| `true` / URL | `true` | Две кнопки: основная `🚀 Подключиться` (Mini App, PRIMARY) и под ней резервная `🔗 Подключиться (резерв)` (Url, без подсветки) |