### PR TITLE
fix: subscription change treated as renewal

### DIFF
--- a/src/telegram/routers/subscription/getters.py
+++ b/src/telegram/routers/subscription/getters.py
@@ -235,6 +235,7 @@ async def confirm_getter(
     plan = retort.load(raw_plan, PlanDto)
     selected_duration = dialog_manager.dialog_data["selected_duration"]
     only_single_duration = dialog_manager.dialog_data.get("only_single_duration", False)
+    only_single_plan = dialog_manager.dialog_data.get("only_single_plan", False)
     is_free = dialog_manager.dialog_data.get("is_free", False)
     selected_payment_method = dialog_manager.dialog_data["selected_payment_method"]
     purchase_type = dialog_manager.dialog_data["purchase_type"]
@@ -271,6 +272,7 @@ async def confirm_getter(
         "url": result_url,
         "only_single_gateway": len(gateways) == 1,
         "only_single_duration": only_single_duration,
+        "only_single_plan": only_single_plan,
         "is_free": is_free,
     }
 

--- a/src/telegram/routers/subscription/handlers.py
+++ b/src/telegram/routers/subscription/handlers.py
@@ -35,8 +35,8 @@ class CachedPaymentData(TypedDict):
     final_pricing: str
 
 
-def _get_cache_key(duration: int, gateway_type: PaymentGatewayType) -> str:
-    return f"{duration}:{gateway_type.value}"
+def _get_cache_key(duration: int, gateway_type: PaymentGatewayType, purchase_type: PurchaseType) -> str:
+    return f"{purchase_type}:{duration}:{gateway_type.value}"
 
 
 def _load_payment_data(dialog_manager: DialogManager) -> dict[str, CachedPaymentData]:
@@ -114,6 +114,7 @@ async def on_purchase_type_select(
     gateways = await payment_gateway_dao.get_active()
     dialog_manager.dialog_data["purchase_type"] = purchase_type
     dialog_manager.dialog_data.pop(CURRENT_DURATION_KEY, None)
+    dialog_manager.dialog_data.pop(PAYMENT_CACHE_KEY, None)
 
     if not plans:
         logger.warning(f"{user.log} No available subscription plans")
@@ -180,6 +181,7 @@ async def on_subscription_plans(  # noqa: C901
     dialog_manager.dialog_data["purchase_type"] = purchase_type
 
     dialog_manager.dialog_data.pop(CURRENT_DURATION_KEY, None)
+    dialog_manager.dialog_data.pop(PAYMENT_CACHE_KEY, None)
 
     if not plans:
         logger.warning(f"{user.log} No available subscription plans")
@@ -325,8 +327,9 @@ async def on_duration_select(
         selected_payment_method = gateways[0].type
         dialog_manager.dialog_data[CURRENT_METHOD_KEY] = selected_payment_method
 
+        purchase_type: PurchaseType = dialog_manager.dialog_data["purchase_type"]
         cache = _load_payment_data(dialog_manager)
-        cache_key = _get_cache_key(selected_duration, selected_payment_method)
+        cache_key = _get_cache_key(selected_duration, selected_payment_method, purchase_type)
 
         if cache_key in cache:
             logger.info(f"{user.log} Re-selected same duration and single gateway")
@@ -375,8 +378,9 @@ async def on_payment_method_select(
 
     selected_duration = dialog_manager.dialog_data[CURRENT_DURATION_KEY]
     dialog_manager.dialog_data[CURRENT_METHOD_KEY] = selected_payment_method
+    purchase_type: PurchaseType = dialog_manager.dialog_data["purchase_type"]
     cache = _load_payment_data(dialog_manager)
-    cache_key = _get_cache_key(selected_duration, selected_payment_method)
+    cache_key = _get_cache_key(selected_duration, selected_payment_method, purchase_type)
 
     if cache_key in cache:
         logger.info(f"{user.log} Re-selected same method and duration")


### PR DESCRIPTION
# fix: subscription change treated as renewal

## Проблема

При определённой последовательности действий оплата за смену подписки (например, с 1 на 2 устройства) обрабатывалась ботом как **продление**, а не как **изменение**.

**Как воспроизвести:**
1. Нажать «Продлить подписку» → выбрать срок → открыть страницу оплаты
2. Закрыть страницу оплаты, не заплатив, вернуться назад в диалоге
3. Нажать «Изменить подписку» → выбрать другой план
4. Оплатить — бот видит операцию как продление и не обновит план

---

## Причина

В диалоге подписки используется локальный кэш платёжных транзакций (`payment_cache` в `dialog_data`). Ключ кэша строился только из срока и платёжного шлюза:

```python
# было
def _get_cache_key(duration: int, gateway_type: PaymentGatewayType) -> str:
    return f"{duration}:{gateway_type.value}"
```

Из-за этого транзакция, созданная при **продлении** (RENEW), попадала в кэш под тем же ключом, что и транзакция для **изменения** (CHANGE) с тем же сроком и шлюзом. При последующем выборе срока в потоке CHANGE происходил cache hit — и бот отправлял пользователя оплачивать старую RENEW-транзакцию.

Усугублял ситуацию второй баг: `confirm_getter` не возвращал `only_single_plan` в своём словаре, поэтому кнопка «назад к планам» на экране подтверждения была **всегда видна** (фильтр `~F["only_single_plan"]` вычислялся в `True` при отсутствующем ключе). Это позволяло пользователю навигировать назад внутри диалога без сброса стека — и `dialog_data` с грязным кэшем сохранялся.

---

## Что изменено

### `handlers.py`

**1. `_get_cache_key` — добавлен `purchase_type` в ключ кэша**

Теперь RENEW и CHANGE транзакции для одного и того же срока/шлюза никогда не коллизируют в кэше.

```python
# стало
def _get_cache_key(duration: int, gateway_type: PaymentGatewayType, purchase_type: PurchaseType) -> str:
    return f"{purchase_type}:{duration}:{gateway_type.value}"
```

**2. `on_subscription_plans` и `on_purchase_type_select` — сброс кэша при смене типа покупки**

При каждом нажатии на «Продлить», «Изменить» или «Новая подписка» кэш платежей теперь принудительно очищается.

```python
dialog_manager.dialog_data.pop(CURRENT_DURATION_KEY, None)
dialog_manager.dialog_data.pop(PAYMENT_CACHE_KEY, None)  # добавлено
```

**3. `on_duration_select` и `on_payment_method_select` — `purchase_type` передаётся в `_get_cache_key`**

### `getters.py`

**4. `confirm_getter` — добавлен `only_single_plan` в возвращаемый словарь**

Кнопка «назад к планам» на экране подтверждения теперь корректно скрывается в потоке RENEW (где план выбирается автоматически и возврат к списку планов не имеет смысла).

```python
only_single_plan = dialog_manager.dialog_data.get("only_single_plan", False)
# ...
return {
    ...
    "only_single_plan": only_single_plan,  # добавлено
}
```
