### PR TITLE
Increase referral code length from 6 to 9 characters

### DIFF
--- a/src/infrastructure/services/cryptography.py
+++ b/src/infrastructure/services/cryptography.py
@@ -94,10 +94,10 @@ class CryptographerImpl(Cryptographer):
     def is_encrypted(self, value: str) -> bool:
         return isinstance(value, str) and value.startswith(ENCRYPTED_PREFIX)
 
-    def generate_short_code(self, data: Any, length: int = 6) -> str:
+    def generate_short_code(self, data: Any, length: int = 9) -> str:
         payload = f"{data}:{self.config.crypt_key.get_secret_value()}"
         digest = hashlib.sha256(payload.encode("utf-8")).digest()
-        code_int = int.from_bytes(digest[:6], "big")
+        code_int = int.from_bytes(digest[:8], "big")
         full_code = self.base62_encode(code_int)
 
         result = full_code[:length].rjust(length, "0")


### PR DESCRIPTION
This change increases generated referral codes from 6 to 9 characters and uses 8 bytes of the SHA-256 digest instead of 6.

The current 6-character referral code has a noticeable collision risk as the user base grows. For example, with around 100,000 users, the probability of at least one referral code collision is approximately 8.43%.

With 9-character referral codes, the collision risk for the same 100,000 users drops to approximately 0.0000369%.