### PR TITLE
Added Webhooks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,3 +96,17 @@ DATABASE_PASSWORD=change_me
 
 # REMNAWAVE_CF_CLIENT_ID=""
 # REMNAWAVE_CF_CLIENT_SECRET=""
+
+# Outbound webhooks: POST bot events (e.g. successful payments) to your own endpoint.
+# The JSON body is signed with HMAC-SHA256 of the raw body (header: X-Webhook-Signature).
+# Also sent: X-Webhook-Event (event class name), X-Webhook-Event-Id (UUID, use for
+# idempotency — retries may deliver the same event twice), X-Webhook-Timestamp (unix seconds).
+# Any 2xx response acknowledges delivery; failures are retried with backoff (see below).
+# WEBHOOK_ENABLED=false
+# WEBHOOK_URL=""
+# WEBHOOK_SECRET=""
+# WEBHOOK_TIMEOUT=15
+# Total delivery attempts (including the first one) and base delay in seconds
+# between attempts (exponential backoff with jitter is applied on top).
+# WEBHOOK_RETRIES=5
+# WEBHOOK_RETRY_DELAY=15

--- a/WEBHOOK_CONTRACT.md
+++ b/WEBHOOK_CONTRACT.md
@@ -1,0 +1,219 @@
+# Контракт: приём webhook-событий от Remnashop
+
+Remnashop (Telegram-бот продажи VPN-подписок) отправляет HTTP-уведомления о доменных
+событиях на ваш endpoint. Этот документ — всё, что нужно для реализации обработчика.
+
+## 1. Транспорт
+
+- **Метод:** `POST` на один URL (путь любой, задаётся на стороне бота).
+- **Content-Type:** `application/json`, тело в UTF-8, компактный JSON (без пробелов).
+- **Таймаут отправителя:** 15 секунд (настраиваемо). Отвечайте быстро; тяжёлую
+  обработку выполняйте асинхронно после ответа.
+- **Подтверждение доставки:** любой ответ `2xx`. Тело ответа игнорируется.
+- **Ретраи:** при не-2xx, таймауте или сетевой ошибке отправитель повторит запрос.
+  По умолчанию всего 5 попыток с экспоненциальной задержкой (база 15 сек × номер
+  попытки + джиттер, потолок 120 сек). Число попыток и база настраиваемы.
+
+## 2. Заголовки запроса
+
+| Заголовок | Пример | Описание |
+|---|---|---|
+| `X-Webhook-Signature` | `3f2a…` (64 hex) | HMAC-SHA256 от сырых байтов тела, hex lowercase |
+| `X-Webhook-Event` | `UserPurchaseEvent` | Тип события (имя класса) |
+| `X-Webhook-Event-Id` | UUID | Уникальный ID события — **ключ идемпотентности** |
+| `X-Webhook-Timestamp` | `1783108730` | Unix-время отправки (секунды, UTC) |
+| `Content-Type` | `application/json` | |
+
+## 3. Проверка подписи (обязательно)
+
+Общий секрет (строка) передаётся вам по защищённому каналу отдельно.
+
+```python
+import hashlib, hmac
+
+def verify(raw_body: bytes, signature_header: str, secret: str) -> bool:
+    expected = hmac.new(secret.encode(), raw_body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature_header)
+```
+
+Критично:
+
+1. **Считайте HMAC от сырых байтов тела запроса** — до какого-либо JSON-парсинга.
+   Никогда не пересериализуйте распарсенный JSON для проверки: порядок ключей,
+   пробелы и экранирование не совпадут, и подпись «сломается».
+2. Сравнивайте через constant-time функцию (`hmac.compare_digest` и аналоги).
+3. Невалидная подпись → ответ `401`, тело не обрабатывать.
+4. (Рекомендуется) отклоняйте запросы с `|now - X-Webhook-Timestamp| > 300` сек —
+   защита от replay. Учтите: ретрай приходит с новым timestamp и той же подписью тела.
+
+## 4. Идемпотентность
+
+Из-за ретраев одно событие может быть доставлено **более одного раза**
+(например, если вы ответили 200, но ответ не дошёл). Храните обработанные
+`X-Webhook-Event-Id` (он же `event_id` в теле) и повторную доставку
+подтверждайте `200` без повторной обработки.
+
+## 5. Тело запроса
+
+Конверт одинаков для всех типов событий:
+
+```json
+{
+  "event_id": "uuid",
+  "event_type": "ИмяКлассаСобытия",
+  "occurred_at": "ISO-8601 с таймзоной (UTC)",
+  "data": { "...поля события..." }
+}
+```
+
+`data` дублирует `event_id`/`occurred_at` — это нормально, игнорируйте.
+
+**Неизвестные типы событий отвечайте `200` и пропускайте**: набор событий будет
+расширяться, обработчик не должен падать на новом `event_type`. Аналогично —
+не делайте strict-валидацию на «лишние» поля внутри `data`.
+
+## 6. Событие `UserPurchaseEvent` (успешная оплата)
+
+Отправляется после успешного проведения платежа и выдачи подписки.
+
+```json
+{
+  "event_id": "0f80a4ba-c979-47d2-afb4-e88996960465",
+  "event_type": "UserPurchaseEvent",
+  "occurred_at": "2026-07-03T18:38:50.339656+00:00",
+  "data": {
+    "event_id": "0f80a4ba-c979-47d2-afb4-e88996960465",
+    "occurred_at": "2026-07-03T18:38:50.339656+00:00",
+    "notification_type": "SUBSCRIPTION",
+
+    "user_id": 42,
+    "telegram_id": 123456789,
+    "username": "testuser",
+    "email": null,
+    "name": "Test User",
+
+    "purchase_type": "NEW",
+    "is_trial_plan": false,
+
+    "payment_id": "dcf883b6-0ba6-48c5-822b-a06c534cac8c",
+    "gateway_type": "TELEGRAM_STARS",
+    "final_amount": "99.90",
+    "original_amount": "111.00",
+    "discount_percent": 10,
+    "currency": "₽",
+
+    "plan_name": ["Premium", {}],
+    "plan_type": "TRAFFIC",
+    "plan_traffic_limit": "100 GB",
+    "plan_device_limit": "3",
+    "plan_duration": "30 days",
+
+    "previous_plan_name": "N/A",
+    "previous_plan_type": {"key": "plan-type", "plan_type": "N/A"},
+    "previous_plan_traffic_limit": "N/A",
+    "previous_plan_device_limit": "N/A",
+    "previous_plan_duration": "N/A"
+  }
+}
+```
+
+### Поля `data`
+
+| Поле | Тип | Описание |
+|---|---|---|
+| `user_id` | int | ID пользователя в боте |
+| `telegram_id` | int \| null | Telegram ID пользователя |
+| `username` | string \| null | Telegram username (без `@`) |
+| `email` | string \| null | Email, если известен |
+| `name` | string | Отображаемое имя |
+| `purchase_type` | `"NEW"` \| `"RENEW"` \| `"CHANGE"` | Новая покупка / продление / смена тарифа |
+| `is_trial_plan` | bool | Куплен ли триальный план |
+| `payment_id` | string (UUID) | ID транзакции в боте — для сверки с платёжкой |
+| `gateway_type` | string | Платёжный шлюз: `TELEGRAM_STARS`, `YOOKASSA`, `CRYPTOMUS`, `CRYPTOPAY`, `ROBOKASSA` и др. |
+| `final_amount` | **string** (decimal) | Сумма, реально уплаченная пользователем (после скидки). Строка — парсить как Decimal, не float |
+| `original_amount` | **string** (decimal) | Цена до скидки |
+| `discount_percent` | int | Применённая скидка, 0–100 |
+| `currency` | string | **Символ** валюты (`"₽"`, `"$"`, `"⭐"`), не ISO-код |
+| `plan_name` | `[string, object]` | Имя тарифа — брать элемент `[0]` |
+| `plan_type` | string | Тип плана (например, `TRAFFIC`) |
+| `plan_traffic_limit` | string | Готовая строка («100 GB», «Unlimited») |
+| `plan_device_limit` | string | Готовая строка |
+| `plan_duration` | string | Готовая строка («30 days») |
+| `previous_plan_*` | string \| object | Прежний тариф; осмысленны только при `purchase_type = "CHANGE"`, иначе `"N/A"` |
+| `notification_type` | string | Служебное, игнорировать |
+
+Примечания:
+- `final_amount == "0"` возможен (100% скидка).
+- Для `gateway_type = "TELEGRAM_STARS"` сумма указана в звёздах (`currency = "⭐"`).
+- Поля `plan_*` — человекочитаемые строки, не для арифметики. Для сверки денег
+  используйте `final_amount` + `payment_id`.
+
+## 7. Матрица ответов обработчика
+
+| Ситуация | Ваш ответ | Что сделает отправитель |
+|---|---|---|
+| Подпись валидна, событие обработано | `200` | Считает доставленным |
+| Подпись валидна, событие-дубликат | `200` | Считает доставленным |
+| Подпись валидна, неизвестный `event_type` | `200` | Считает доставленным |
+| Невалидная подпись | `401` | Ретрай (подпись не изменится — после исчерпания попыток событие потеряно, алерт админам бота) |
+| Временная ошибка на вашей стороне (БД недоступна и т.п.) | `5xx` | Ретрай с backoff |
+
+## 8. Референс-обработчик (FastAPI)
+
+```python
+import hashlib
+import hmac
+import json
+import os
+
+from fastapi import FastAPI, Header, HTTPException, Request, Response
+
+app = FastAPI()
+SECRET = os.environ["REMNASHOP_WEBHOOK_SECRET"]
+processed_ids: set[str] = set()  # в проде — таблица/Redis с TTL
+
+
+@app.post("/remnashop/webhook")
+async def remnashop_webhook(
+    request: Request,
+    x_webhook_signature: str = Header(...),
+    x_webhook_event: str = Header(...),
+    x_webhook_event_id: str = Header(...),
+) -> Response:
+    raw_body = await request.body()  # сырые байты — ДО парсинга
+
+    expected = hmac.new(SECRET.encode(), raw_body, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, x_webhook_signature):
+        raise HTTPException(status_code=401, detail="Invalid signature")
+
+    if x_webhook_event_id in processed_ids:
+        return Response(status_code=200)  # дубликат — уже обработано
+
+    payload = json.loads(raw_body)
+
+    if x_webhook_event == "UserPurchaseEvent":
+        data = payload["data"]
+        # ... ваша логика: data["payment_id"], data["final_amount"], ...
+    # неизвестные события — молча подтверждаем
+
+    processed_ids.add(x_webhook_event_id)
+    return Response(status_code=200)
+```
+
+## 9. Тестовые данные
+
+Для локальной проверки подписи (секрет `test_secret_123`):
+
+```bash
+BODY='{"event_id":"test","event_type":"UserPurchaseEvent","occurred_at":"2026-07-03T00:00:00+00:00","data":{}}'
+printf '%s' "$BODY" | openssl dgst -sha256 -hmac "test_secret_123" -hex
+# → подпись для заголовка X-Webhook-Signature
+
+curl -X POST http://localhost:8000/remnashop/webhook \
+  -H "Content-Type: application/json" \
+  -H "X-Webhook-Signature: <подпись из команды выше>" \
+  -H "X-Webhook-Event: UserPurchaseEvent" \
+  -H "X-Webhook-Event-Id: test" \
+  -H "X-Webhook-Timestamp: $(date +%s)" \
+  -d "$BODY"
+```

--- a/src/core/config/app.py
+++ b/src/core/config/app.py
@@ -19,6 +19,7 @@ from .log import LogConfig
 from .redis import RedisConfig
 from .remnawave import RemnawaveConfig
 from .validators import validate_not_change_me
+from .webhook import OutboundWebhookConfig
 
 
 class AppConfig(BaseConfig, env_prefix="APP_"):
@@ -43,6 +44,7 @@ class AppConfig(BaseConfig, env_prefix="APP_"):
     database: DatabaseConfig = Field(default_factory=DatabaseConfig)
     redis: RedisConfig = Field(default_factory=RedisConfig)
     email: EmailConfig = Field(default_factory=EmailConfig)
+    webhook: OutboundWebhookConfig = Field(default_factory=OutboundWebhookConfig)
     build: BuildConfig = Field(default_factory=BuildConfig)
     log: LogConfig = Field(default_factory=LogConfig)
 

--- a/src/core/config/webhook.py
+++ b/src/core/config/webhook.py
@@ -1,0 +1,27 @@
+from pydantic import Field, SecretStr, model_validator
+
+from .base import BaseConfig
+
+
+class OutboundWebhookConfig(BaseConfig, env_prefix="WEBHOOK_"):
+    enabled: bool = False
+
+    url: str = ""
+    secret: SecretStr = SecretStr("")
+    timeout: float = 15.0
+
+    # Total delivery attempts (including the first one) and base delay between
+    # them; the broker applies exponential backoff with jitter on top.
+    retries: int = Field(default=5, ge=1)
+    retry_delay: float = Field(default=15.0, gt=0)
+
+    @model_validator(mode="after")
+    def validate_webhook_settings(self) -> "OutboundWebhookConfig":
+        if self.enabled:
+            if not self.url.startswith(("http://", "https://")):
+                raise ValueError(
+                    "WEBHOOK_URL must be a valid http(s) URL when WEBHOOK_ENABLED=true"
+                )
+            if not self.secret.get_secret_value():
+                raise ValueError("WEBHOOK_SECRET must be set when WEBHOOK_ENABLED=true")
+        return self

--- a/src/infrastructure/common/json.py
+++ b/src/infrastructure/common/json.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 from typing import Any, Union
+from uuid import UUID
 
 import orjson
 from aiogram.types import InlineKeyboardMarkup
@@ -26,6 +27,10 @@ def _default_processor(obj: Any) -> Any:
     if isinstance(obj, SecretStr):
         return obj.get_secret_value()
     if isinstance(obj, Decimal):
+        return str(obj)
+    # orjson serializes exact `uuid.UUID` natively, but not subclasses such as
+    # asyncpg's pgproto UUID, which reach here — stringify any UUID subtype.
+    if isinstance(obj, UUID):
         return str(obj)
     if isinstance(obj, InlineKeyboardMarkup):
         return obj.model_dump()

--- a/src/infrastructure/common/json.py
+++ b/src/infrastructure/common/json.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import Any, Union
 
 import orjson
@@ -24,6 +25,8 @@ def bytes_encode(data: Any) -> bytes:
 def _default_processor(obj: Any) -> Any:
     if isinstance(obj, SecretStr):
         return obj.get_secret_value()
+    if isinstance(obj, Decimal):
+        return str(obj)
     if isinstance(obj, InlineKeyboardMarkup):
         return obj.model_dump()
     raise TypeError(f"Object of type '{type(obj).__name__}' is not JSON serializable")

--- a/src/infrastructure/di/providers/services.py
+++ b/src/infrastructure/di/providers/services.py
@@ -32,6 +32,8 @@ from src.infrastructure.services import (
     NotificationQueue,
     NotificationService,
     NotificationWorker,
+    OutboundWebhookSender,
+    OutboundWebhookService,
     PasswordHasherImpl,
     PaymentNotificationDispatcherImpl,
     RedirectImpl,
@@ -60,6 +62,9 @@ class ServicesProvider(Provider):
 
     command = provide(source=CommandService)
     webhook = provide(source=WebhookService)
+
+    outbound_webhook = provide(source=OutboundWebhookService)
+    outbound_webhook_sender = provide(source=OutboundWebhookSender)
 
     remnawave = provide(source=RemnawaveImpl, provides=Remnawave)
     remna_webhook = provide(source=RemnaWebhookService, scope=Scope.REQUEST)

--- a/src/infrastructure/services/__init__.py
+++ b/src/infrastructure/services/__init__.py
@@ -9,6 +9,7 @@ from .health import HealthService
 from .http_client import AiohttpClient
 from .notification import NotificationService
 from .notification_queue import NotificationQueue, NotificationWorker
+from .outbound_webhook import OutboundWebhookSender, OutboundWebhookService
 from .password_hasher import PasswordHasherImpl
 from .redirect import RedirectImpl
 from .remnawave import RemnawaveImpl
@@ -29,6 +30,8 @@ __all__ = [
     "NotificationService",
     "NotificationQueue",
     "NotificationWorker",
+    "OutboundWebhookSender",
+    "OutboundWebhookService",
     "PasswordHasherImpl",
     "PaymentNotificationDispatcherImpl",
     "RedirectImpl",

--- a/src/infrastructure/services/outbound_webhook.py
+++ b/src/infrastructure/services/outbound_webhook.py
@@ -1,0 +1,84 @@
+import hashlib
+import hmac
+import time
+from dataclasses import asdict
+
+import aiohttp
+from loguru import logger
+
+from src.application.events import BaseEvent, UserPurchaseEvent
+from src.core.config import AppConfig
+from src.infrastructure.common import json
+from src.infrastructure.services.event_bus import on_event
+
+# Extension point: add an event type here to start delivering it.
+OUTBOUND_WEBHOOK_EVENTS: tuple[type[BaseEvent], ...] = (UserPurchaseEvent,)
+
+SIGNATURE_HEADER = "X-Webhook-Signature"
+EVENT_HEADER = "X-Webhook-Event"
+EVENT_ID_HEADER = "X-Webhook-Event-Id"
+TIMESTAMP_HEADER = "X-Webhook-Timestamp"
+
+
+class OutboundWebhookService:
+    def __init__(self, config: AppConfig) -> None:
+        self._config = config
+
+    @on_event(*OUTBOUND_WEBHOOK_EVENTS)
+    async def enqueue_delivery(self, event: BaseEvent) -> None:
+        if not self._config.webhook.enabled:
+            return
+
+        # Local import breaks the module cycle (tasks/webhooks.py imports the sender
+        # from this package).
+        from src.infrastructure.taskiq.tasks.webhooks import (  # noqa: PLC0415
+            send_outbound_webhook_task,
+        )
+
+        payload = json.encode(
+            {
+                "event_id": event.event_id,
+                "event_type": event.event_type,
+                "occurred_at": event.occurred_at,
+                "data": asdict(event),
+            }
+        ).decode()
+
+        webhook = self._config.webhook
+        await (
+            send_outbound_webhook_task.kicker()
+            .with_labels(max_retries=webhook.retries, delay=webhook.retry_delay)
+            .kiq(payload, event.event_type, str(event.event_id))  # type: ignore[call-overload]
+        )
+        logger.info(f"Outbound webhook enqueued for event '{event.event_type}'")
+
+
+class OutboundWebhookSender:
+    def __init__(self, config: AppConfig) -> None:
+        self._config = config
+
+    async def deliver(self, payload: str, event_type: str, event_id: str) -> None:
+        settings = self._config.webhook
+        body = payload.encode("utf-8")
+        secret = settings.secret.get_secret_value().encode("utf-8")
+        signature = hmac.new(secret, body, hashlib.sha256).hexdigest()
+
+        headers = {
+            "Content-Type": "application/json",
+            SIGNATURE_HEADER: signature,
+            EVENT_HEADER: event_type,
+            EVENT_ID_HEADER: event_id,
+            TIMESTAMP_HEADER: str(int(time.time())),
+        }
+
+        timeout = aiohttp.ClientTimeout(total=settings.timeout)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(settings.url, data=body, headers=headers) as response:
+                if response.status >= 300:
+                    text = (await response.text())[:200]
+                    raise RuntimeError(
+                        f"Outbound webhook to '{settings.url}' failed: "
+                        f"HTTP {response.status} {text}"
+                    )
+
+        logger.info(f"Outbound webhook delivered: '{event_type}' ({event_id})")

--- a/src/infrastructure/taskiq/middlewares.py
+++ b/src/infrastructure/taskiq/middlewares.py
@@ -19,6 +19,17 @@ class ErrorMiddleware(TaskiqMiddleware):
     ) -> None:
         logger.error(f"Task '{message.task_name}' error: {exception}")
 
+        # For retryable tasks, notify admins only after the final attempt
+        # (SmartRetryMiddleware increments '_retries' the same way before comparing).
+        if str(message.labels.get("retry_on_error", "")).lower() in ("true", "1"):
+            retries = int(message.labels.get("_retries", 0)) + 1
+            max_retries = int(message.labels.get("max_retries", 5))
+            if retries < max_retries:
+                logger.warning(
+                    f"Task '{message.task_name}' will be retried ({retries}/{max_retries})"
+                )
+                return
+
         container: Optional[AsyncContainer] = self.broker.custom_dependency_context.get(
             AsyncContainer
         )

--- a/src/infrastructure/taskiq/tasks/webhooks.py
+++ b/src/infrastructure/taskiq/tasks/webhooks.py
@@ -1,0 +1,15 @@
+from dishka.integrations.taskiq import FromDishka, inject
+
+from src.infrastructure.services import OutboundWebhookSender
+from src.infrastructure.taskiq.broker import broker
+
+
+@broker.task(retry_on_error=True)
+@inject(patch_module=True)
+async def send_outbound_webhook_task(
+    payload: str,
+    event_type: str,
+    event_id: str,
+    sender: FromDishka[OutboundWebhookSender],
+) -> None:
+    await sender.deliver(payload, event_type, event_id)


### PR DESCRIPTION
 **Why**                                                                                                                                               

Sometimes you want to build a wrapper or integration on top of Remnashop and plug it into your own systems (CRM, billing, analytics, a companion  backend). To do that you need visibility into what's actually happening inside the bot — when a user buys a subscription, renews, etc.            
                                                                                                                                                    
Until now those events lived only inside the bot (an in-process event bus plus Telegram notifications), so an external service had no clean way to react to them short of polling the database.                                                                                                      
                                                                                                                                                    
With this change the project starts pushing its events out as webhooks. No code changes are required on the bot side to enable it — you just set a few environment variables, point it at your endpoint, and start receiving signed event notifications. 
  
 **What**                                                                                                                                              
                                                                                                                                                    
Adds an outbound webhook mechanism: Remnashop now delivers domain events (currently UserPurchaseEvent) to an external HTTP endpoint as an  HMAC-SHA256–signed JSON POST, with retries and idempotency support.                                                                               
                                                                                                                                                    
**Delivery pipeline**                                                                                                                                 
  - OutboundWebhookService subscribes to selected domain events on the event bus and enqueues a delivery job.                                       
  - OutboundWebhookSender builds the JSON payload, computes the HMAC signature over the raw body, and sends it via aiohttp.                         
  - send_outbound_webhook_task (Taskiq) performs the delivery with automatic retries (exponential backoff + jitter), so transient failures on the   
  receiver don't drop events.                                                                                                                       
                                                                                                                                                    
  Contract                                                                                                                                          
  - POST, Content-Type: application/json, compact UTF-8 JSON body.                                                                                  
  - Headers: X-Webhook-Signature (HMAC-SHA256 of the raw body, hex), X-Webhook-Event (event class name), X-Webhook-Event-Id (UUID — idempotency key,
  since retries may redeliver the same event), X-Webhook-Timestamp (unix seconds).                                                                  
  - Any 2xx acknowledges delivery; anything else is retried.                                                                                        
  - New event types can be enabled by adding them to a single tuple (OUTBOUND_WEBHOOK_EVENTS).