### PR TITLE
 Integrated the UnitPay payment system.      

### DIFF
--- a/assets/translations/ru/messages.ftl
+++ b/assets/translations/ru/messages.ftl
@@ -1096,6 +1096,11 @@ msg-gateways-field =
 
     Введите новое значение для { $field ->
         [display_name] отображаемого названия
+        [test_mode] режима работы — впишите <code>true</code> для тестового режима (нужен тестовый секретный ключ) или <code>false</code> для боевого
+        [public_key] публичного ключа
+        [secret_key] секретного ключа
+        [vat] ставки НДС для чека — впишите одно из: <code>none</code> (без НДС), <code>vat0</code>, <code>vat5</code>, <code>vat7</code>, <code>vat10</code>, <code>vat20</code>
+        [customer_email] email для отправки чека покупателю
        *[other] { $field }
     }.
 

--- a/assets/translations/ru/messages.ftl
+++ b/assets/translations/ru/messages.ftl
@@ -1100,7 +1100,6 @@ msg-gateways-field =
         [public_key] публичного ключа
         [secret_key] секретного ключа
         [vat] ставки НДС для чека — впишите одно из: <code>none</code> (без НДС), <code>vat0</code>, <code>vat5</code>, <code>vat7</code>, <code>vat10</code>, <code>vat20</code>
-        [customer_email] email для отправки чека покупателю
        *[other] { $field }
     }.
 

--- a/assets/translations/ru/messages.ftl
+++ b/assets/translations/ru/messages.ftl
@@ -1100,6 +1100,7 @@ msg-gateways-field =
         [public_key] публичного ключа
         [secret_key] секретного ключа
         [vat] ставки НДС для чека — впишите одно из: <code>none</code> (без НДС), <code>vat0</code>, <code>vat5</code>, <code>vat7</code>, <code>vat10</code>, <code>vat20</code>
+        [payment_type] метода оплаты (код платежной системы UnitPay) — например <code>card</code>, <code>applepay</code>, <code>googlepay</code>, <code>sbp</code>, <code>qiwi</code>. По умолчанию <code>card</code>
        *[other] { $field }
     }.
 

--- a/assets/translations/ru/messages.ftl
+++ b/assets/translations/ru/messages.ftl
@@ -1099,7 +1099,7 @@ msg-gateways-field =
         [test_mode] режима работы — впишите <code>true</code> для тестового режима (нужен тестовый секретный ключ) или <code>false</code> для боевого
         [public_key] публичного ключа
         [secret_key] секретного ключа
-        [vat] ставки НДС для чека — впишите одно из: <code>none</code> (без НДС), <code>vat0</code>, <code>vat5</code>, <code>vat7</code>, <code>vat10</code>, <code>vat20</code>
+        [vat] ставки НДС для чека — впишите одно из: <code>none</code> (без чека, e-mail не запрашивается), <code>vat0</code>, <code>vat5</code>, <code>vat7</code>, <code>vat10</code>, <code>vat20</code>
         [payment_type] метода оплаты (код платежной системы UnitPay) — например <code>card</code>, <code>applepay</code>, <code>googlepay</code>, <code>sbp</code>, <code>qiwi</code>. По умолчанию <code>card</code>
        *[other] { $field }
     }.

--- a/assets/translations/ru/utils.ftl
+++ b/assets/translations/ru/utils.ftl
@@ -355,6 +355,7 @@ gateway-type = { $gateway_type ->
     [URLPAY] UrlPay
     [WATA] WATA
     [VALUTIX] Valutix
+    [UNITPAY] UnitPay
     *[OTHER] { $gateway_type }
 }
 

--- a/src/application/common/invoice.py
+++ b/src/application/common/invoice.py
@@ -1,0 +1,19 @@
+from src.application.common.translator import TranslatorRunner
+from src.application.dto.plan import PlanSnapshotDto
+from src.core.enums import PurchaseType
+from src.core.utils.i18n_helpers import i18n_format_days
+
+
+def build_invoice_description(
+    i18n: TranslatorRunner,
+    purchase_type: PurchaseType,
+    plan_snapshot: PlanSnapshotDto,
+) -> str:
+    """Render the human-readable payment description shown on the invoice/receipt."""
+    key, kw = i18n_format_days(plan_snapshot.duration)
+    return i18n.get(
+        "payment-invoice-description",
+        purchase_type=purchase_type,
+        name=i18n.get(plan_snapshot.name),
+        duration=i18n.get(key, **kw),
+    )

--- a/src/application/dto/payment_gateway.py
+++ b/src/application/dto/payment_gateway.py
@@ -166,6 +166,23 @@ class ValutixGatewaySettingsDto(GatewaySettingsDto):
     api_key: Optional[SecretStr] = None
 
 
+@dataclass(kw_only=True)
+class UnitPayGatewaySettingsDto(GatewaySettingsDto):
+    type: Literal[PaymentGatewayType.UNITPAY] = PaymentGatewayType.UNITPAY
+    public_key: Optional[str] = None
+    secret_key: Optional[SecretStr] = None
+    # When True, requests carry test=1 and must use the project's TEST secret key.
+    test_mode: bool = False
+    # Fiscal receipt (54-ФЗ): set `vat` (none/vat0/vat10/vat20/...) to attach a
+    # receipt; UnitPay delivers it to `customer_email` when provided.
+    vat: Optional[str] = None
+    customer_email: Optional[str] = None
+
+    @property
+    def is_configured(self) -> bool:
+        return self.public_key is not None and self.secret_key is not None
+
+
 AnyGatewaySettingsDto = Union[
     TelegramStarsGatewaySettingsDto,
     YooKassaGatewaySettingsDto,
@@ -181,4 +198,5 @@ AnyGatewaySettingsDto = Union[
     UrlPayGatewaySettingsDto,
     WataGatewaySettingsDto,
     ValutixGatewaySettingsDto,
+    UnitPayGatewaySettingsDto,
 ]

--- a/src/application/dto/payment_gateway.py
+++ b/src/application/dto/payment_gateway.py
@@ -176,6 +176,10 @@ class UnitPayGatewaySettingsDto(GatewaySettingsDto):
     # Fiscal receipt (54-ФЗ): set `vat` (none/vat0/vat10/vat20/...) to attach a
     # receipt. The delivery email is collected per-payment on the hosted page.
     vat: Optional[str] = None
+    # UnitPay payment-system code (paymentType), e.g. card / applepay / googlepay /
+    # sbp / qiwi. Defaults to `card` in the gateway when unset.
+    # https://help.unitpay.ru/en/book-of-reference/payment-system-codes
+    payment_type: Optional[str] = None
 
     @property
     def is_configured(self) -> bool:

--- a/src/application/dto/payment_gateway.py
+++ b/src/application/dto/payment_gateway.py
@@ -174,9 +174,8 @@ class UnitPayGatewaySettingsDto(GatewaySettingsDto):
     # When True, requests carry test=1 and must use the project's TEST secret key.
     test_mode: bool = False
     # Fiscal receipt (54-ФЗ): set `vat` (none/vat0/vat10/vat20/...) to attach a
-    # receipt; UnitPay delivers it to `customer_email` when provided.
+    # receipt. The delivery email is collected per-payment on the hosted page.
     vat: Optional[str] = None
-    customer_email: Optional[str] = None
 
     @property
     def is_configured(self) -> bool:

--- a/src/application/use_cases/gateways/commands/payment.py
+++ b/src/application/use_cases/gateways/commands/payment.py
@@ -39,6 +39,7 @@ from src.application.dto.payment_gateway import (
     PlategaGatewaySettingsDto,
     RoboKassaGatewaySettingsDto,
     TelegramStarsGatewaySettingsDto,
+    UnitPayGatewaySettingsDto,
     UrlPayGatewaySettingsDto,
     ValutixGatewaySettingsDto,
     WataGatewaySettingsDto,
@@ -105,6 +106,7 @@ class CreateDefaultPaymentGateway(Interactor[None, None]):
                     PaymentGatewayType.URLPAY: UrlPayGatewaySettingsDto,
                     PaymentGatewayType.VALUTIX: ValutixGatewaySettingsDto,
                     PaymentGatewayType.WATA: WataGatewaySettingsDto,
+                    PaymentGatewayType.UNITPAY: UnitPayGatewaySettingsDto,
                 }
                 dto_class = settings_map.get(gateway_type)
                 settings = dto_class() if dto_class else None

--- a/src/application/use_cases/gateways/commands/payment.py
+++ b/src/application/use_cases/gateways/commands/payment.py
@@ -18,6 +18,7 @@ from src.application.common.dao import (
     TransactionDao,
     UserDao,
 )
+from src.application.common.invoice import build_invoice_description
 from src.application.common.policy import Permission
 from src.application.common.uow import UnitOfWork
 from src.application.dto import (
@@ -165,13 +166,7 @@ class CreatePayment(Interactor[CreatePaymentDto, PaymentResultDto]):
         gateway_instance = await self.get_payment_gateway_instance.system(data.gateway_type)
         i18n = self.translator_hub.get_translator_by_locale(actor.language)
 
-        key, kw = i18n_format_days(data.plan_snapshot.duration)
-        details = i18n.get(
-            "payment-invoice-description",
-            purchase_type=data.purchase_type,
-            name=i18n.get(data.plan_snapshot.name),
-            duration=i18n.get(key, **kw),
-        )
+        details = build_invoice_description(i18n, data.purchase_type, data.plan_snapshot)
 
         if data.pricing.is_free:
             async with self.uow:

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -39,6 +39,7 @@ API_V1: Final[str] = "/api/v1"
 BOT_WEBHOOK_PATH: Final[str] = "/telegram"
 PAYMENTS_WEBHOOK_PATH: Final[str] = "/payments"
 REMNAWAVE_WEBHOOK_PATH: Final[str] = "/remnawave"
+UNITPAY_PAY_PATH: Final[str] = "/pay/unitpay"
 
 IMPORTED_TAG: Final[str] = "IMPORTED"
 INLINE_QUERY_INVITE: Final[str] = "invite"

--- a/src/core/enums.py
+++ b/src/core/enums.py
@@ -96,6 +96,7 @@ class PaymentGatewayType(UpperStrEnum):
     ROBOKASSA = auto()
     URLPAY = auto()
     WATA = auto()
+    UNITPAY = auto()
 
 
 class PurchaseType(UpperStrEnum):
@@ -323,6 +324,7 @@ class Currency(UpperStrEnum):
             PaymentGatewayType.URLPAY: cls.RUB,
             PaymentGatewayType.WATA: cls.RUB,
             PaymentGatewayType.VALUTIX: cls.RUB,
+            PaymentGatewayType.UNITPAY: cls.RUB,
         }
 
         try:

--- a/src/infrastructure/database/migrations/versions/0041_add_unitpay_payment_gateway.py
+++ b/src/infrastructure/database/migrations/versions/0041_add_unitpay_payment_gateway.py
@@ -1,0 +1,16 @@
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0041"
+down_revision: Union[str, None] = "0040"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE payment_gateway_type ADD VALUE IF NOT EXISTS 'UNITPAY'")
+
+
+def downgrade() -> None:
+    pass

--- a/src/infrastructure/di/providers/payment_gateways.py
+++ b/src/infrastructure/di/providers/payment_gateways.py
@@ -21,6 +21,7 @@ from src.infrastructure.payment_gateways import (
     PlategaGateway,
     RobokassaGateway,
     TelegramStarsGateway,
+    UnitPayGateway,
     UrlPayGateway,
     ValutixGateway,
     WataGateway,
@@ -43,6 +44,7 @@ GATEWAY_MAP: dict[PaymentGatewayType, Type[BasePaymentGateway]] = {
     PaymentGatewayType.URLPAY: UrlPayGateway,
     PaymentGatewayType.VALUTIX: ValutixGateway,
     PaymentGatewayType.WATA: WataGateway,
+    PaymentGatewayType.UNITPAY: UnitPayGateway,
 }
 
 

--- a/src/infrastructure/di/providers/retort.py
+++ b/src/infrastructure/di/providers/retort.py
@@ -42,6 +42,7 @@ from src.application.dto.payment_gateway import (
     PlategaGatewaySettingsDto,
     RoboKassaGatewaySettingsDto,
     TelegramStarsGatewaySettingsDto,
+    UnitPayGatewaySettingsDto,
     UrlPayGatewaySettingsDto,
     ValutixGatewaySettingsDto,
     WataGatewaySettingsDto,
@@ -117,6 +118,7 @@ class RetortProvider(Provider):
                 PaymentGatewayType.URLPAY: UrlPayGatewaySettingsDto,
                 PaymentGatewayType.VALUTIX: ValutixGatewaySettingsDto,
                 PaymentGatewayType.WATA: WataGatewaySettingsDto,
+                PaymentGatewayType.UNITPAY: UnitPayGatewaySettingsDto,
             }
 
             dto_class = type_mapping.get(pg_type)

--- a/src/infrastructure/payment_gateways/__init__.py
+++ b/src/infrastructure/payment_gateways/__init__.py
@@ -8,6 +8,7 @@ from .pay_master import PayMasterGateway
 from .platega import PlategaGateway
 from .robokassa import RobokassaGateway
 from .telegram_stars import TelegramStarsGateway
+from .unitpay import UnitPayGateway
 from .url_pay import UrlPayGateway
 from .valutix import ValutixGateway
 from .wata import WataGateway
@@ -26,6 +27,7 @@ __all__ = [
     "PlategaGateway",
     "RobokassaGateway",
     "TelegramStarsGateway",
+    "UnitPayGateway",
     "UrlPayGateway",
     "ValutixGateway",
     "WataGateway",

--- a/src/infrastructure/payment_gateways/unitpay.py
+++ b/src/infrastructure/payment_gateways/unitpay.py
@@ -35,6 +35,7 @@ class UnitPayGateway(BasePaymentGateway):
     # created via the initPayment API, which returns a ready-to-open redirectUrl.
     INIT_METHOD: Final[str] = "initPayment"
     # UnitPay requires an explicit payment method; the bare method-chooser form 404s.
+    # Used as the default when the gateway's `payment_type` setting is unset.
     PAYMENT_TYPE: Final[str] = "card"
     METHOD_PAY: Final[str] = "pay"
 
@@ -59,6 +60,7 @@ class UnitPayGateway(BasePaymentGateway):
         self._secret_key = settings.secret_key.get_secret_value()
         self._test_mode = settings.test_mode
         self._vat = settings.vat
+        self._payment_type = settings.payment_type or self.PAYMENT_TYPE
 
         self._client = self._make_client(base_url=self.API_BASE)
 
@@ -76,7 +78,7 @@ class UnitPayGateway(BasePaymentGateway):
         signed = {
             "account": str(account),
             "desc": desc[:128],
-            "paymentType": self.PAYMENT_TYPE,
+            "paymentType": self._payment_type,
             "projectId": self._project_id,
             "sum": self._format_amount(amount),
         }

--- a/src/infrastructure/payment_gateways/unitpay.py
+++ b/src/infrastructure/payment_gateways/unitpay.py
@@ -59,20 +59,33 @@ class UnitPayGateway(BasePaymentGateway):
         self._project_id = settings.public_key.split("-", 1)[0]
         self._secret_key = settings.secret_key.get_secret_value()
         self._test_mode = settings.test_mode
-        self._vat = settings.vat
+        # A fiscal receipt is attached only when a real VAT rate is set; `None` and
+        # the literal "none" both mean "no receipt" (and thus no email to collect).
+        vat = settings.vat
+        self._vat = vat if vat and vat.strip().lower() != "none" else None
         self._payment_type = settings.payment_type or self.PAYMENT_TYPE
 
         self._client = self._make_client(base_url=self.API_BASE)
 
     async def handle_create_payment(self, amount: Decimal, details: str) -> PaymentResultDto:
-        # The UnitPay payment is created only after the user enters an email on the
-        # hosted page (create_hosted_payment); here we just mint the order id and
-        # point the Pay button at that page. Contract (amount/details) is untouched.
         order_id = uuid.uuid4()
-        return PaymentResultDto(id=order_id, url=self._hosted_page_url(order_id))
+        # A fiscal receipt needs the buyer's email, which is collected on the hosted
+        # page before the payment is created (create_hosted_payment). Without a
+        # receipt there is nothing to collect, so create the payment now and point
+        # the Pay button straight at UnitPay. Contract (amount/details) is untouched.
+        if self._vat is not None:
+            return PaymentResultDto(id=order_id, url=self._hosted_page_url(order_id))
+
+        url = await self._init_payment(order_id, amount, details, customer_email=None)
+        return PaymentResultDto(id=order_id, url=url)
 
     async def create_hosted_payment(
         self, account: UUID, amount: Decimal, desc: str, customer_email: str
+    ) -> str:
+        return await self._init_payment(account, amount, desc, customer_email)
+
+    async def _init_payment(
+        self, account: UUID, amount: Decimal, desc: str, customer_email: Optional[str]
     ) -> str:
         # `test` and `secretKey` are NOT part of the signature; everything else is.
         signed = {
@@ -87,7 +100,7 @@ class UnitPayGateway(BasePaymentGateway):
         for key, value in signed.items():
             query[f"params[{key}]"] = value
         # cashItems / customerEmail are extra params — UnitPay does not sign them.
-        if self._vat is not None:
+        if self._vat is not None and customer_email is not None:
             query["params[cashItems]"] = self._build_cash_items(signed["desc"], amount)
             query["params[customerEmail]"] = customer_email
         if self._test_mode:

--- a/src/infrastructure/payment_gateways/unitpay.py
+++ b/src/infrastructure/payment_gateways/unitpay.py
@@ -17,6 +17,7 @@ from loguru import logger
 from src.application.dto import PaymentGatewayDto, PaymentResultDto
 from src.application.dto.payment_gateway import UnitPayGatewaySettingsDto
 from src.core.config import AppConfig
+from src.core.constants import API_V1, UNITPAY_PAY_PATH
 from src.core.enums import TransactionStatus
 
 from .base import BasePaymentGateway
@@ -58,16 +59,23 @@ class UnitPayGateway(BasePaymentGateway):
         self._secret_key = settings.secret_key.get_secret_value()
         self._test_mode = settings.test_mode
         self._vat = settings.vat
-        self._customer_email = settings.customer_email
 
         self._client = self._make_client(base_url=self.API_BASE)
 
     async def handle_create_payment(self, amount: Decimal, details: str) -> PaymentResultDto:
+        # The UnitPay payment is created only after the user enters an email on the
+        # hosted page (create_hosted_payment); here we just mint the order id and
+        # point the Pay button at that page. Contract (amount/details) is untouched.
         order_id = uuid.uuid4()
+        return PaymentResultDto(id=order_id, url=self._hosted_page_url(order_id))
+
+    async def create_hosted_payment(
+        self, account: UUID, amount: Decimal, desc: str, customer_email: str
+    ) -> str:
         # `test` and `secretKey` are NOT part of the signature; everything else is.
         signed = {
-            "account": str(order_id),
-            "desc": details[:128],
+            "account": str(account),
+            "desc": desc[:128],
             "paymentType": self.PAYMENT_TYPE,
             "projectId": self._project_id,
             "sum": self._format_amount(amount),
@@ -79,20 +87,19 @@ class UnitPayGateway(BasePaymentGateway):
         # cashItems / customerEmail are extra params — UnitPay does not sign them.
         if self._vat is not None:
             query["params[cashItems]"] = self._build_cash_items(signed["desc"], amount)
-            if self._customer_email:
-                query["params[customerEmail]"] = self._customer_email
+            query["params[customerEmail]"] = customer_email
         if self._test_mode:
             query["params[test]"] = "1"
         query["params[secretKey]"] = self._secret_key
         query["params[signature]"] = self._sign(signed, method=self.INIT_METHOD)
 
-        logger.debug(f"Creating UnitPay payment '{order_id}' (test={self._test_mode})")
+        logger.debug(f"Creating UnitPay payment '{account}' (test={self._test_mode})")
 
         try:
             response = await self._client.get("api", params=query)
             response.raise_for_status()
             data = orjson.loads(response.content)
-            return self._get_payment_data(order_id, data)
+            return self._extract_redirect_url(data)
 
         except HTTPStatusError as e:
             logger.error(
@@ -103,6 +110,10 @@ class UnitPayGateway(BasePaymentGateway):
         except (KeyError, orjson.JSONDecodeError) as e:
             logger.error(f"Failed to parse UnitPay response. Error: {e}")
             raise
+
+    def _hosted_page_url(self, order_id: UUID) -> str:
+        domain = self.config.domain.get_secret_value()
+        return f"https://{domain}{API_V1}{UNITPAY_PAY_PATH}/{order_id}"
 
     async def handle_webhook(self, request: Request) -> Union[tuple[UUID, TransactionStatus], None]:
         logger.debug(f"Received {self.__class__.__name__} webhook request")
@@ -130,7 +141,7 @@ class UnitPayGateway(BasePaymentGateway):
         # UnitPay treats any {"result": {"message": ...}} body as an acknowledgement.
         return JSONResponse({"result": {"message": "OK"}})
 
-    def _get_payment_data(self, order_id: UUID, data: dict[str, Any]) -> PaymentResultDto:
+    def _extract_redirect_url(self, data: dict[str, Any]) -> str:
         if "error" in data:
             message = data["error"].get("message", "unknown error")
             raise ValueError(f"UnitPay refused payment creation: {message}")
@@ -139,7 +150,7 @@ class UnitPayGateway(BasePaymentGateway):
         if not redirect_url:
             raise KeyError("Invalid UnitPay response: missing 'result.redirectUrl'")
 
-        return PaymentResultDto(id=order_id, url=str(redirect_url))
+        return str(redirect_url)
 
     def _parse_request(self, request: Request) -> tuple[str, dict[str, str]]:
         method = request.query_params.get("method", "")

--- a/src/infrastructure/payment_gateways/unitpay.py
+++ b/src/infrastructure/payment_gateways/unitpay.py
@@ -1,0 +1,187 @@
+import base64
+import hashlib
+import re
+import uuid
+from decimal import Decimal
+from hmac import compare_digest
+from typing import Any, Final, Optional, Union, cast
+from uuid import UUID
+
+import orjson
+from aiogram import Bot
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from httpx import AsyncClient, HTTPStatusError
+from loguru import logger
+
+from src.application.dto import PaymentGatewayDto, PaymentResultDto
+from src.application.dto.payment_gateway import UnitPayGatewaySettingsDto
+from src.core.config import AppConfig
+from src.core.enums import TransactionStatus
+
+from .base import BasePaymentGateway
+
+
+# https://help.unitpay.ru/
+class UnitPayGateway(BasePaymentGateway):
+    _client: AsyncClient
+
+    API_BASE: Final[str] = "https://unitpay.ru"
+    # UnitPay concatenates signed values with this literal separator before hashing.
+    SEPARATOR: Final[str] = "{up}"
+
+    # The `/pay/{publicKey}` form is disabled for API-driven projects; payments are
+    # created via the initPayment API, which returns a ready-to-open redirectUrl.
+    INIT_METHOD: Final[str] = "initPayment"
+    # UnitPay requires an explicit payment method; the bare method-chooser form 404s.
+    PAYMENT_TYPE: Final[str] = "card"
+    METHOD_PAY: Final[str] = "pay"
+
+    _PARAM_RE: Final[re.Pattern[str]] = re.compile(r"params\[(?P<key>.+)]")
+
+    def __init__(self, gateway: PaymentGatewayDto, bot: Bot, config: AppConfig) -> None:
+        super().__init__(gateway, bot, config)
+
+        if not isinstance(self.data.settings, UnitPayGatewaySettingsDto):
+            raise TypeError(
+                f"Invalid settings type: expected {UnitPayGatewaySettingsDto.__name__}, "
+                f"got {type(self.data.settings).__name__}"
+            )
+
+        settings = cast(UnitPayGatewaySettingsDto, self.data.settings)
+        if settings.public_key is None or settings.secret_key is None:
+            raise ValueError("UnitPay gateway is not configured")
+
+        self._public_key = settings.public_key
+        # Public key is "<projectId>-<hash>"; the API authenticates by projectId.
+        self._project_id = settings.public_key.split("-", 1)[0]
+        self._secret_key = settings.secret_key.get_secret_value()
+        self._test_mode = settings.test_mode
+        self._vat = settings.vat
+        self._customer_email = settings.customer_email
+
+        self._client = self._make_client(base_url=self.API_BASE)
+
+    async def handle_create_payment(self, amount: Decimal, details: str) -> PaymentResultDto:
+        order_id = uuid.uuid4()
+        # `test` and `secretKey` are NOT part of the signature; everything else is.
+        signed = {
+            "account": str(order_id),
+            "desc": details[:128],
+            "paymentType": self.PAYMENT_TYPE,
+            "projectId": self._project_id,
+            "sum": self._format_amount(amount),
+        }
+
+        query: dict[str, str] = {"method": self.INIT_METHOD}
+        for key, value in signed.items():
+            query[f"params[{key}]"] = value
+        # cashItems / customerEmail are extra params — UnitPay does not sign them.
+        if self._vat is not None:
+            query["params[cashItems]"] = self._build_cash_items(signed["desc"], amount)
+            if self._customer_email:
+                query["params[customerEmail]"] = self._customer_email
+        if self._test_mode:
+            query["params[test]"] = "1"
+        query["params[secretKey]"] = self._secret_key
+        query["params[signature]"] = self._sign(signed, method=self.INIT_METHOD)
+
+        logger.debug(f"Creating UnitPay payment '{order_id}' (test={self._test_mode})")
+
+        try:
+            response = await self._client.get("api", params=query)
+            response.raise_for_status()
+            data = orjson.loads(response.content)
+            return self._get_payment_data(order_id, data)
+
+        except HTTPStatusError as e:
+            logger.error(
+                f"HTTP error creating UnitPay payment. "
+                f"Status: '{e.response.status_code}', Body: {e.response.text}"
+            )
+            raise
+        except (KeyError, orjson.JSONDecodeError) as e:
+            logger.error(f"Failed to parse UnitPay response. Error: {e}")
+            raise
+
+    async def handle_webhook(self, request: Request) -> Union[tuple[UUID, TransactionStatus], None]:
+        logger.debug(f"Received {self.__class__.__name__} webhook request")
+
+        method, params = self._parse_request(request)
+        logger.debug(f"UnitPay webhook data: method='{method}', params={params}")
+
+        if not self._verify_webhook(method, params):
+            raise PermissionError("Webhook verification failed")
+
+        # UnitPay probes with `check` before charging and reports `error` on failure;
+        # only `pay` confirms a completed payment. Other methods are acknowledged
+        # without a status change.
+        if method != self.METHOD_PAY:
+            logger.debug(f"UnitPay '{method}' notification acknowledged without status change")
+            return None
+
+        account = params.get("account")
+        if not account:
+            raise ValueError("Required field 'params[account]' is missing")
+
+        return UUID(account), TransactionStatus.COMPLETED
+
+    async def build_webhook_response(self, request: Request) -> JSONResponse:
+        # UnitPay treats any {"result": {"message": ...}} body as an acknowledgement.
+        return JSONResponse({"result": {"message": "OK"}})
+
+    def _get_payment_data(self, order_id: UUID, data: dict[str, Any]) -> PaymentResultDto:
+        if "error" in data:
+            message = data["error"].get("message", "unknown error")
+            raise ValueError(f"UnitPay refused payment creation: {message}")
+
+        redirect_url = data.get("result", {}).get("redirectUrl")
+        if not redirect_url:
+            raise KeyError("Invalid UnitPay response: missing 'result.redirectUrl'")
+
+        return PaymentResultDto(id=order_id, url=str(redirect_url))
+
+    def _parse_request(self, request: Request) -> tuple[str, dict[str, str]]:
+        method = request.query_params.get("method", "")
+        params: dict[str, str] = {}
+        for key, value in request.query_params.items():
+            match = self._PARAM_RE.fullmatch(key)
+            if match:
+                params[match.group("key")] = value
+        return method, params
+
+    def _verify_webhook(self, method: str, params: dict[str, str]) -> bool:
+        received = params.get("signature")
+        if not received:
+            logger.warning("UnitPay webhook is missing 'params[signature]'")
+            return False
+
+        expected = self._sign(params, method=method)
+        if not compare_digest(expected, received):
+            logger.warning("Invalid UnitPay webhook signature")
+            return False
+
+        return True
+
+    def _sign(self, params: dict[str, str], method: Optional[str] = None) -> str:
+        # sha256 of `[method] + <values sorted by key> + secretKey`, joined by `{up}`.
+        parts = [params[key] for key in sorted(params) if key not in ("sign", "signature")]
+        if method is not None:
+            parts.insert(0, method)
+        parts.append(self._secret_key)
+        raw = self.SEPARATOR.join(parts)
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    def _build_cash_items(self, name: str, amount: Decimal) -> str:
+        # UnitPay expects a base64-encoded JSON array of receipt positions.
+        item = {
+            "name": name,
+            "count": 1,
+            "price": float(amount),
+            "nds": self._vat,
+        }
+        return base64.b64encode(orjson.dumps([item])).decode()
+
+    @staticmethod
+    def _format_amount(amount: Decimal) -> str:
+        return format(amount.quantize(Decimal("0.01")), "f")

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -16,6 +16,7 @@ from .endpoints import (
     payments_router,
     public_router,
     remnawave_router,
+    unitpay_pay_router,
 )
 
 
@@ -47,6 +48,7 @@ def get_app(config: AppConfig, dispatcher: Dispatcher) -> FastAPI:
     app.include_router(health_router)
     app.include_router(payments_router)
     app.include_router(remnawave_router)
+    app.include_router(unitpay_pay_router)
     if config.web_enabled:
         app.include_router(public_router)
 

--- a/src/web/endpoints/__init__.py
+++ b/src/web/endpoints/__init__.py
@@ -3,6 +3,7 @@ from .payments import router as payments_router
 from .public import router as public_router
 from .remnawave import router as remnawave_router
 from .telegram import TelegramWebhookEndpoint
+from .unitpay import router as unitpay_pay_router
 
 __all__ = [
     "health_router",
@@ -10,4 +11,5 @@ __all__ = [
     "public_router",
     "remnawave_router",
     "TelegramWebhookEndpoint",
+    "unitpay_pay_router",
 ]

--- a/src/web/endpoints/payments.py
+++ b/src/web/endpoints/payments.py
@@ -135,3 +135,26 @@ async def payments_webhook(
         transaction_dao=transaction_dao,
         uow=uow,
     )
+
+
+# Some gateways (e.g. UnitPay) deliver notifications via GET.
+@router.get("/{gateway_type}")
+@inject
+async def payments_webhook_get(
+    gateway_type: str,
+    request: Request,
+    config: FromDishka[AppConfig],
+    event_publisher: FromDishka[EventPublisher],
+    get_payment_gateway_instance: FromDishka[GetPaymentGatewayInstance],
+    transaction_dao: FromDishka[TransactionDao],
+    uow: FromDishka[UnitOfWork],
+) -> Response:
+    return await _process_payment_webhook(
+        gateway_type=gateway_type,
+        request=request,
+        config=config,
+        event_publisher=event_publisher,
+        get_payment_gateway_instance=get_payment_gateway_instance,
+        transaction_dao=transaction_dao,
+        uow=uow,
+    )

--- a/src/web/endpoints/unitpay.py
+++ b/src/web/endpoints/unitpay.py
@@ -1,0 +1,169 @@
+import re
+from decimal import Decimal
+from typing import Optional
+from uuid import UUID
+
+from dishka import FromDishka
+from dishka.integrations.fastapi import inject
+from fastapi import APIRouter, Form, Response, status
+from fastapi.responses import HTMLResponse, RedirectResponse
+from loguru import logger
+
+from src.application.common import TranslatorHub
+from src.application.common.dao import TransactionDao, UserDao
+from src.application.common.invoice import build_invoice_description
+from src.application.dto import TransactionDto
+from src.application.use_cases.gateways.queries.providers import GetPaymentGatewayInstance
+from src.core.config import AppConfig
+from src.core.constants import API_V1, UNITPAY_PAY_PATH
+from src.core.enums import PaymentGatewayType, TransactionStatus
+from src.infrastructure.payment_gateways import UnitPayGateway
+
+router = APIRouter(prefix=API_V1 + UNITPAY_PAY_PATH, include_in_schema=False)
+
+# Matches the de-facto email pattern used across src/web/schemas/auth.py.
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+_STYLE = (
+    ":root{color-scheme:light dark}*{box-sizing:border-box}"
+    "body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;"
+    "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;"
+    "background:#f4f5f7;color:#1c1c1e;padding:16px}"
+    ".card{background:#fff;border-radius:16px;padding:28px 24px;max-width:380px;width:100%;"
+    "box-shadow:0 10px 40px rgba(0,0,0,.12)}"
+    "h1{font-size:19px;margin:0 0 6px}p{margin:0 0 18px;font-size:14px;opacity:.7}"
+    "label{display:block;font-size:13px;margin-bottom:6px;opacity:.8}"
+    "input{width:100%;padding:12px 14px;font-size:15px;border:1px solid #d0d0d5;border-radius:10px;"
+    "margin-bottom:14px}"
+    "button{width:100%;padding:13px;font-size:15px;font-weight:600;border:0;border-radius:10px;"
+    "background:#2ea44f;color:#fff;cursor:pointer}button:hover{background:#2c974b}"
+    ".err{color:#d1242f;font-size:13px;margin:-6px 0 12px}"
+    "@media(prefers-color-scheme:dark){body{background:#121214;color:#f2f2f5}"
+    ".card{background:#1e1e22}input{background:#0f0f12;color:#f2f2f5;border-color:#3a3a3f}}"
+)
+
+
+def _page(body: str) -> str:
+    return (
+        '<!doctype html><html lang="ru"><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">'
+        f"<title>Оплата</title><style>{_STYLE}</style></head>"
+        f'<body><div class="card">{body}</div></body></html>'
+    )
+
+
+def _form_page(
+    payment_id: UUID, amount: Decimal, symbol: str, error: Optional[str] = None
+) -> str:
+    err_html = f'<div class="err">{error}</div>' if error else ""
+    action = f"{API_V1}{UNITPAY_PAY_PATH}/{payment_id}"
+    body = (
+        "<h1>Оплата подписки</h1>"
+        f"<p>К оплате: <b>{amount} {symbol}</b></p>"
+        f'<form method="post" action="{action}">'
+        '<label for="email">E-mail для чека</label>'
+        '<input id="email" type="email" name="email" required '
+        'placeholder="you@example.com" autofocus>'
+        f"{err_html}"
+        '<button type="submit">Перейти к оплате</button></form>'
+    )
+    return _page(body)
+
+
+def _error_page(message: str) -> str:
+    return _page(f"<h1>Ошибка</h1><p>{message}</p>")
+
+
+async def _load_pending_unitpay(
+    transaction_dao: TransactionDao, payment_id: UUID
+) -> Optional[TransactionDto]:
+    transaction = await transaction_dao.get_by_payment_id(payment_id)
+    if (
+        transaction is None
+        or transaction.status != TransactionStatus.PENDING
+        or transaction.gateway_type != PaymentGatewayType.UNITPAY
+    ):
+        return None
+    return transaction
+
+
+@router.get("/{payment_id}")
+@inject
+async def unitpay_page(
+    payment_id: UUID,
+    transaction_dao: FromDishka[TransactionDao],
+) -> Response:
+    transaction = await _load_pending_unitpay(transaction_dao, payment_id)
+    if transaction is None:
+        return HTMLResponse(
+            _error_page("Платёж не найден или уже обработан."),
+            status_code=status.HTTP_404_NOT_FOUND,
+        )
+    return HTMLResponse(
+        _form_page(payment_id, transaction.pricing.final_amount, transaction.currency.symbol)
+    )
+
+
+@router.post("/{payment_id}")
+@inject
+async def unitpay_submit(
+    payment_id: UUID,
+    transaction_dao: FromDishka[TransactionDao],
+    user_dao: FromDishka[UserDao],
+    translator_hub: FromDishka[TranslatorHub],
+    get_payment_gateway_instance: FromDishka[GetPaymentGatewayInstance],
+    config: FromDishka[AppConfig],
+    email: str = Form(...),
+) -> Response:
+    transaction = await _load_pending_unitpay(transaction_dao, payment_id)
+    if transaction is None:
+        return HTMLResponse(
+            _error_page("Платёж не найден или уже обработан."),
+            status_code=status.HTTP_404_NOT_FOUND,
+        )
+
+    email = email.strip().lower()
+    if not _EMAIL_RE.match(email):
+        return HTMLResponse(
+            _form_page(
+                payment_id,
+                transaction.pricing.final_amount,
+                transaction.currency.symbol,
+                error="Введите корректный e-mail.",
+            ),
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    user = await user_dao.get_by_id(transaction.user_id)
+    locale = user.language if user else config.default_locale
+    i18n = translator_hub.get_translator_by_locale(locale)
+    desc = build_invoice_description(i18n, transaction.purchase_type, transaction.plan_snapshot)
+
+    try:
+        gateway = await get_payment_gateway_instance.system(PaymentGatewayType.UNITPAY)
+    except Exception as e:
+        logger.warning(f"UnitPay gateway unavailable for '{payment_id}': {e}")
+        return HTMLResponse(
+            _error_page("Платёжный шлюз недоступен."),
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    if not isinstance(gateway, UnitPayGateway):
+        logger.error(f"Expected UnitPayGateway, got '{type(gateway).__name__}'")
+        return HTMLResponse(
+            _error_page("Платёжный шлюз недоступен."),
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    try:
+        redirect_url = await gateway.create_hosted_payment(
+            payment_id, transaction.pricing.final_amount, desc, email
+        )
+    except Exception as e:
+        logger.exception(f"UnitPay payment creation failed for '{payment_id}': {e}")
+        return HTMLResponse(
+            _error_page("Не удалось создать платёж. Попробуйте позже."),
+            status_code=status.HTTP_502_BAD_GATEWAY,
+        )
+
+    return RedirectResponse(redirect_url, status_code=status.HTTP_303_SEE_OTHER)


### PR DESCRIPTION
To issue fiscal receipts, UnitPay requires the customer's email. To collect it without changing the project's code (the shared gateway contract), I added a separate page: the
  user fills in the email field, and only then does the UnitPay payment page open.                                                                                              
                                                                                                                                                                                
This way the email is collected right before payment and goes into the receipt, while the rest of the payment logic stays untouched.

---

Для выставления фискальных чеков UnitPay требует email клиента. Чтобы получить его, не меняя код проекта (общий контракт шлюзов), я добавил отдельную страницу: пользователь  
  заполняет поле email, и только после этого открывается платёжная страница UnitPay.                                                                                            
                                                                                                                                                                                
Так email собирается прямо перед оплатой и уходит в чек, а остальная логика оплаты остаётся нетронутой.