### PR TITLE
fix(config): allow loopback web cabinet URLs

### DIFF
--- a/src/core/config/app.py
+++ b/src/core/config/app.py
@@ -1,6 +1,8 @@
 import re
+from ipaddress import ip_address
 from pathlib import Path
 from typing import Optional, Self
+from urllib.parse import urlsplit
 
 from pydantic import Field, SecretStr, field_validator, model_validator
 from pydantic_core.core_schema import FieldValidationInfo
@@ -105,7 +107,24 @@ class AppConfig(BaseConfig, env_prefix="APP_"):
     def validate_web_cabinet_url(cls, value: str) -> str:
         url = value.strip()
         if url and not is_valid_url(url):
-            raise ValueError("WEB_CABINET_URL must be an HTTPS URL")
+            parsed = urlsplit(url)
+            hostname = parsed.hostname
+            is_loopback = hostname == "localhost"
+            if hostname and not is_loopback:
+                try:
+                    is_loopback = ip_address(hostname).is_loopback
+                except ValueError:
+                    pass
+
+            if (
+                parsed.scheme != "http"
+                or not is_loopback
+                or parsed.username is not None
+                or parsed.password is not None
+            ):
+                raise ValueError(
+                    "WEB_CABINET_URL must be an HTTPS URL or an HTTP loopback URL"
+                )
         return url
 
     @field_validator("crypt_key")

--- a/tests/unit/core/config/test_app.py
+++ b/tests/unit/core/config/test_app.py
@@ -1,0 +1,30 @@
+import pytest
+
+from src.core.config.app import AppConfig
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://cabinet.example.com",
+        "http://localhost:4000",
+        "http://127.0.0.1:4000/payment/pending",
+        "http://[::1]:4000",
+    ],
+)
+def test_web_cabinet_url_accepts_https_and_http_loopback(url: str) -> None:
+    assert AppConfig.validate_web_cabinet_url(url) == url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://cabinet.example.com",
+        "http://localhost.example.com",
+        "http://localhost@attacker.example.com",
+        "ftp://localhost:4000",
+    ],
+)
+def test_web_cabinet_url_rejects_non_loopback_http(url: str) -> None:
+    with pytest.raises(ValueError, match="HTTPS URL or an HTTP loopback URL"):
+        AppConfig.validate_web_cabinet_url(url)


### PR DESCRIPTION
## Summary

Allow `WEB_CABINET_URL` to use plain HTTP only for explicit loopback hosts (`localhost`, `127.0.0.0/8`, or `::1`). HTTPS remains required for every non-loopback host.

The validator rejects credentials in the URL and lookalike hostnames such as `localhost.example.com`, so this supports local/container development without weakening remote deployment validation.

## Verification

- `pytest -q tests/unit/core/config/test_app.py`: 8 passed
- `ruff check src/core/config/app.py tests/unit/core/config/test_app.py`: passed
- `mypy src/core/config/app.py`: passed
- `git diff --check upstream/dev...HEAD`: passed

## Context

This focused change was split out of #135 so it can be reviewed and merged independently from the Clean Pay integration.