### PR TITLE
feat(bot): support custom Telegram API base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,8 @@ DATABASE_PASSWORD=change_me
 # WEB_ENABLED=false
 # WEB_CABINET_URL="https://lk.example.org/auth/telegram/webapp"
 
+# Optional custom Telegram Bot API server, for example a local Bot API container.
+# BOT_API_BASE_URL="http://telegram-bot-api:8081"
 # BOT_PROXY_URL=""
 # BOT_RESET_WEBHOOK=false
 # BOT_DROP_PENDING_UPDATES=false

--- a/src/core/config/bot.py
+++ b/src/core/config/bot.py
@@ -1,4 +1,5 @@
 from typing import Optional, Union
+from urllib.parse import urlsplit
 
 from pydantic import SecretStr, field_validator
 from pydantic_core.core_schema import FieldValidationInfo
@@ -17,6 +18,7 @@ class BotConfig(BaseConfig, env_prefix="BOT_"):
     support_username: SecretStr
     mini_app: Union[bool, SecretStr] = False
     proxy_url: Optional[SecretStr] = None
+    api_base_url: Optional[str] = None
 
     reset_webhook: bool = False
     drop_pending_updates: bool = False
@@ -59,6 +61,25 @@ class BotConfig(BaseConfig, env_prefix="BOT_"):
     def validate_bot_support_username(cls, field: object, info: FieldValidationInfo) -> object:
         validate_username(field, info)
         return field
+
+    @field_validator("api_base_url")
+    @classmethod
+    def validate_api_base_url(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+
+        url = value.strip().rstrip("/")
+        parsed = urlsplit(url)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError("BOT_API_BASE_URL must be a valid HTTP(S) base URL")
+        return url
 
     @field_validator("mini_app")
     @classmethod

--- a/src/infrastructure/di/providers/bot.py
+++ b/src/infrastructure/di/providers/bot.py
@@ -1,8 +1,10 @@
 from collections.abc import AsyncIterable
+from typing import Any
 
 from aiogram import Bot
 from aiogram.client.default import DefaultBotProperties
 from aiogram.client.session.aiohttp import AiohttpSession
+from aiogram.client.telegram import TelegramAPIServer
 from aiogram.enums import ParseMode
 from aiogram_dialog import BgManagerFactory
 from dishka import Provider, Scope, from_context, provide
@@ -30,11 +32,7 @@ class BotProvider(Provider):
     async def get_bot(self, config: AppConfig) -> AsyncIterable[Bot]:
         logger.debug("Initializing Bot instance")
 
-        session = None
-        if config.bot.proxy_url:
-            logger.info("Using SOCKS5 proxy for Telegram")
-            proxy = _normalize_proxy_url(config.bot.proxy_url.get_secret_value())
-            session = AiohttpSession(proxy=proxy)
+        session = _build_bot_session(config)
 
         async with Bot(
             token=config.bot.token.get_secret_value(),
@@ -42,3 +40,19 @@ class BotProvider(Provider):
             session=session,
         ) as bot:
             yield bot
+
+
+def _build_bot_session(config: AppConfig) -> AiohttpSession | None:
+    session_kwargs: dict[str, Any] = {}
+
+    if config.bot.api_base_url:
+        logger.info("Using custom Telegram Bot API base URL")
+        session_kwargs["api"] = TelegramAPIServer.from_base(config.bot.api_base_url)
+
+    if config.bot.proxy_url:
+        logger.info("Using SOCKS5 proxy for Telegram")
+        session_kwargs["proxy"] = _normalize_proxy_url(
+            config.bot.proxy_url.get_secret_value()
+        )
+
+    return AiohttpSession(**session_kwargs) if session_kwargs else None

--- a/tests/unit/infrastructure/di/providers/test_bot.py
+++ b/tests/unit/infrastructure/di/providers/test_bot.py
@@ -1,0 +1,81 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from pydantic import SecretStr
+
+from src.core.config.bot import BotConfig
+
+provider_path = Path(__file__).resolve().parents[5] / "src/infrastructure/di/providers/bot.py"
+provider_spec = spec_from_file_location("bot_provider_under_test", provider_path)
+assert provider_spec and provider_spec.loader
+bot_provider = module_from_spec(provider_spec)
+provider_spec.loader.exec_module(bot_provider)
+
+
+def test_custom_bot_api_base_url_can_be_combined_with_proxy(monkeypatch) -> None:
+    api = object()
+    session = object()
+    from_base = Mock(return_value=api)
+    aiohttp_session = Mock(return_value=session)
+    monkeypatch.setattr(
+        bot_provider,
+        "TelegramAPIServer",
+        SimpleNamespace(from_base=from_base),
+    )
+    monkeypatch.setattr(bot_provider, "AiohttpSession", aiohttp_session)
+    config = SimpleNamespace(
+        bot=SimpleNamespace(
+            api_base_url="http://telegram-mock:8081",
+            proxy_url=SecretStr("socks5://proxy.example:1080"),
+        )
+    )
+
+    assert bot_provider._build_bot_session(config) is session
+    from_base.assert_called_once_with("http://telegram-mock:8081")
+    aiohttp_session.assert_called_once_with(
+        api=api,
+        proxy="socks5://proxy.example:1080",
+    )
+
+
+def test_proxy_session_is_used_without_custom_api(monkeypatch) -> None:
+    session = object()
+    aiohttp_session = Mock(return_value=session)
+    monkeypatch.setattr(bot_provider, "AiohttpSession", aiohttp_session)
+    config = SimpleNamespace(
+        bot=SimpleNamespace(
+            api_base_url=None,
+            proxy_url=SecretStr("socks5h://proxy.example:1080"),
+        )
+    )
+
+    assert bot_provider._build_bot_session(config) is session
+    aiohttp_session.assert_called_once_with(proxy="socks5://proxy.example:1080")
+
+
+def test_default_bot_session_uses_aiogram_defaults() -> None:
+    config = SimpleNamespace(bot=SimpleNamespace(api_base_url=None, proxy_url=None))
+
+    assert bot_provider._build_bot_session(config) is None
+
+
+def test_bot_api_base_url_is_normalized() -> None:
+    assert (
+        BotConfig.validate_api_base_url(" http://telegram-mock:8081/ ")
+        == "http://telegram-mock:8081"
+    )
+
+
+def test_bot_api_base_url_rejects_credentials_and_query() -> None:
+    for value in (
+        "http://user:pass@telegram-mock:8081",
+        "http://telegram-mock:8081?token=secret",
+    ):
+        try:
+            BotConfig.validate_api_base_url(value)
+        except ValueError as error:
+            assert "valid HTTP(S) base URL" in str(error)
+        else:
+            raise AssertionError(f"Expected invalid BOT_API_BASE_URL: {value}")


### PR DESCRIPTION
## Summary

Add optional `BOT_API_BASE_URL` configuration for installations that use a self-hosted or test Telegram Bot API server.

- validates and normalizes an HTTP(S) base URL;
- rejects embedded credentials, query strings, and fragments;
- configures aiogram through `TelegramAPIServer.from_base`;
- preserves SOCKS proxy support and allows a custom API endpoint and proxy to be used together;
- documents the variable in `.env.example`.

Default behavior is unchanged when `BOT_API_BASE_URL` is unset.

## Verification

- `pytest -q tests/unit/infrastructure/di/providers/test_bot.py`: 5 passed
- `ruff check` on changed Python files: passed
- `mypy` on changed source files: passed
- `git diff --check upstream/dev`: passed

## Context

This focused feature was split out of #135 so it can be reviewed and merged independently from the Clean Pay integration.