### PR TITLE
fix: support Remnawave 2.8 HWID responses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-remnapy = { git = "https://github.com/snoups/remnapy", rev = "95e15ed" }
+remnapy = { git = "https://github.com/snoups/remnapy", rev = "0680253" }
 
 [project.urls]
 homepage = "https://t.me/@remna_shop"

--- a/uv.lock
+++ b/uv.lock
@@ -1078,8 +1078,8 @@ wheels = [
 
 [[package]]
 name = "remnapy"
-version = "2.7.1.dev4+g95e15ed2e"
-source = { git = "https://github.com/snoups/remnapy?rev=95e15ed#95e15ed2ea29aa62f112a8af790d6151f5db5fb1" }
+version = "0.1.dev174+g06802538e"
+source = { git = "https://github.com/snoups/remnapy?rev=0680253#06802538e9f7671d4387c597b5f1434557ca3dc9" }
 dependencies = [
     { name = "cryptography" },
     { name = "httpx" },
@@ -1152,7 +1152,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "qrcode", extras = ["pil"], specifier = ">=8.2" },
     { name = "redis", specifier = "~=7.0.0" },
-    { name = "remnapy", git = "https://github.com/snoups/remnapy?rev=95e15ed" },
+    { name = "remnapy", git = "https://github.com/snoups/remnapy?rev=0680253" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "taskiq", extras = ["orjson"], specifier = "~=0.12.1" },
     { name = "taskiq-redis", specifier = "~=1.2.1" },


### PR DESCRIPTION
## Summary

- update the pinned `remnapy` revision from `95e15ed` to `0680253`
- refresh `uv.lock` to the exact resolved commit

## Root cause

Remnawave 2.8 changed HWID device responses from `userUuid` (UUID) to `userId` (BigInt). The currently pinned `remnapy` DTO requires `userUuid`, so opening the Devices dialog can fail with a Pydantic validation error when the panel returns the new response shape.

The selected `remnapy` revision includes the Remnawave 2.8 schema while keeping both ownership fields optional for compatibility with older panels. It also retains the legacy aliases used by Remnashop.

## User impact

Users on Remnawave 2.8 can list and manage HWID devices without the response failing DTO validation.

## Validation

- `uv lock --check`
- `uv sync --locked --no-dev --compile-bytecode`
- imported every `remnapy` symbol referenced by Remnashop
- parsed representative HWID payloads with both `userId` and `userUuid`
- validated the patched dependency against Remnawave 2.8.1 in a live deployment; Remnashop, Taskiq worker, and scheduler started cleanly
