### PR TITLE
feat: add 2328.io payment gateway

### DIFF
--- a/assets/translations/ru/utils.ftl
+++ b/assets/translations/ru/utils.ftl
@@ -350,6 +350,7 @@ gateway-type = { $gateway_type ->
     [FREEKASSA] FreeKassa
     [MULENPAY] MulenPay
     [PAYMASTER] PayMaster
+    [PAY_2328] 2328.io Crypto
     [PLATEGA] Platega
     [ROBOKASSA] RoboKassa
     [URLPAY] UrlPay

--- a/src/application/dto/payment_gateway.py
+++ b/src/application/dto/payment_gateway.py
@@ -32,6 +32,7 @@ class PaymentGatewayDto(BaseDto, TrackableMixin):
             PaymentGatewayType.HELEKET,
             PaymentGatewayType.FREEKASSA,
             PaymentGatewayType.PAYMASTER,
+            PaymentGatewayType.PAY_2328,
         }
 
 
@@ -166,6 +167,14 @@ class ValutixGatewaySettingsDto(GatewaySettingsDto):
     api_key: Optional[SecretStr] = None
 
 
+@dataclass(kw_only=True)
+class Pay2328GatewaySettingsDto(GatewaySettingsDto):
+    type: Literal[PaymentGatewayType.PAY_2328] = PaymentGatewayType.PAY_2328
+    project_uuid: Optional[str] = None
+    api_key: Optional[SecretStr] = None
+    ttl_seconds: int = 3600
+
+
 AnyGatewaySettingsDto = Union[
     TelegramStarsGatewaySettingsDto,
     YooKassaGatewaySettingsDto,
@@ -181,4 +190,5 @@ AnyGatewaySettingsDto = Union[
     UrlPayGatewaySettingsDto,
     WataGatewaySettingsDto,
     ValutixGatewaySettingsDto,
+    Pay2328GatewaySettingsDto,
 ]

--- a/src/application/use_cases/gateways/commands/payment.py
+++ b/src/application/use_cases/gateways/commands/payment.py
@@ -34,6 +34,7 @@ from src.application.dto.payment_gateway import (
     FreeKassaGatewaySettingsDto,
     HeleketGatewaySettingsDto,
     MulenPayGatewaySettingsDto,
+    Pay2328GatewaySettingsDto,
     PayMasterGatewaySettingsDto,
     PaymentGatewayDto,
     PlategaGatewaySettingsDto,
@@ -105,6 +106,7 @@ class CreateDefaultPaymentGateway(Interactor[None, None]):
                     PaymentGatewayType.URLPAY: UrlPayGatewaySettingsDto,
                     PaymentGatewayType.VALUTIX: ValutixGatewaySettingsDto,
                     PaymentGatewayType.WATA: WataGatewaySettingsDto,
+                    PaymentGatewayType.PAY_2328: Pay2328GatewaySettingsDto,
                 }
                 dto_class = settings_map.get(gateway_type)
                 settings = dto_class() if dto_class else None

--- a/src/core/enums.py
+++ b/src/core/enums.py
@@ -96,6 +96,7 @@ class PaymentGatewayType(UpperStrEnum):
     ROBOKASSA = auto()
     URLPAY = auto()
     WATA = auto()
+    PAY_2328 = auto()
 
 
 class PurchaseType(UpperStrEnum):
@@ -323,6 +324,7 @@ class Currency(UpperStrEnum):
             PaymentGatewayType.URLPAY: cls.RUB,
             PaymentGatewayType.WATA: cls.RUB,
             PaymentGatewayType.VALUTIX: cls.RUB,
+            PaymentGatewayType.PAY_2328: cls.RUB,
         }
 
         try:

--- a/src/infrastructure/database/migrations/versions/0041_add_pay_2328_payment_gateway.py
+++ b/src/infrastructure/database/migrations/versions/0041_add_pay_2328_payment_gateway.py
@@ -1,0 +1,16 @@
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0041"
+down_revision: Union[str, None] = "0040"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE payment_gateway_type ADD VALUE IF NOT EXISTS 'PAY_2328'")
+
+
+def downgrade() -> None:
+    pass

--- a/src/infrastructure/di/providers/payment_gateways.py
+++ b/src/infrastructure/di/providers/payment_gateways.py
@@ -16,6 +16,7 @@ from src.infrastructure.payment_gateways import (
     FreeKassaGateway,
     HeleketGateway,
     MulenPayGateway,
+    Pay2328Gateway,
     PayMasterGateway,
     PaymentGatewayFactory,
     PlategaGateway,
@@ -43,6 +44,7 @@ GATEWAY_MAP: dict[PaymentGatewayType, Type[BasePaymentGateway]] = {
     PaymentGatewayType.URLPAY: UrlPayGateway,
     PaymentGatewayType.VALUTIX: ValutixGateway,
     PaymentGatewayType.WATA: WataGateway,
+    PaymentGatewayType.PAY_2328: Pay2328Gateway,
 }
 
 

--- a/src/infrastructure/di/providers/retort.py
+++ b/src/infrastructure/di/providers/retort.py
@@ -38,6 +38,7 @@ from src.application.dto.payment_gateway import (
     FreeKassaGatewaySettingsDto,
     HeleketGatewaySettingsDto,
     MulenPayGatewaySettingsDto,
+    Pay2328GatewaySettingsDto,
     PayMasterGatewaySettingsDto,
     PlategaGatewaySettingsDto,
     RoboKassaGatewaySettingsDto,
@@ -117,6 +118,7 @@ class RetortProvider(Provider):
                 PaymentGatewayType.URLPAY: UrlPayGatewaySettingsDto,
                 PaymentGatewayType.VALUTIX: ValutixGatewaySettingsDto,
                 PaymentGatewayType.WATA: WataGatewaySettingsDto,
+                PaymentGatewayType.PAY_2328: Pay2328GatewaySettingsDto,
             }
 
             dto_class = type_mapping.get(pg_type)
@@ -172,6 +174,7 @@ class RetortProvider(Provider):
                         UrlPayGatewaySettingsDto,
                         ValutixGatewaySettingsDto,
                         WataGatewaySettingsDto,
+                        Pay2328GatewaySettingsDto,
                     ]
                 ],
             ]

--- a/src/infrastructure/payment_gateways/__init__.py
+++ b/src/infrastructure/payment_gateways/__init__.py
@@ -4,6 +4,7 @@ from .cryptopay import CryptoPayGateway
 from .freekassa import FreeKassaGateway
 from .heleket import HeleketGateway
 from .mulen_pay import MulenPayGateway
+from .pay_2328 import Pay2328Gateway
 from .pay_master import PayMasterGateway
 from .platega import PlategaGateway
 from .robokassa import RobokassaGateway
@@ -22,6 +23,7 @@ __all__ = [
     "FreeKassaGateway",
     "HeleketGateway",
     "MulenPayGateway",
+    "Pay2328Gateway",
     "PayMasterGateway",
     "PlategaGateway",
     "RobokassaGateway",

--- a/src/infrastructure/payment_gateways/pay_2328.py
+++ b/src/infrastructure/payment_gateways/pay_2328.py
@@ -1,0 +1,148 @@
+import base64
+import hashlib
+import hmac
+from decimal import Decimal
+from typing import Any, Final, Union
+from uuid import UUID, uuid4
+
+import orjson
+from aiogram import Bot
+from fastapi import Request
+from httpx import AsyncClient, HTTPStatusError
+from loguru import logger
+
+from src.__version__ import __version__
+from src.application.dto import PaymentGatewayDto, PaymentResultDto
+from src.application.dto.payment_gateway import Pay2328GatewaySettingsDto
+from src.core.config import AppConfig
+from src.core.enums import TransactionStatus
+
+from .base import BasePaymentGateway
+
+
+# https://doc.2328.io/en/docs/payments
+class Pay2328Gateway(BasePaymentGateway):
+    _client: AsyncClient
+
+    API_BASE: Final[str] = "https://api.2328.io/api"
+
+    def __init__(self, gateway: PaymentGatewayDto, bot: Bot, config: AppConfig) -> None:
+        super().__init__(gateway, bot, config)
+
+        settings = self._get_settings()
+        if not settings.project_uuid or not settings.api_key:
+            raise ValueError("2328.io gateway is not configured")
+
+        self._client = self._make_client(
+            base_url=self.API_BASE,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": (
+                    f"Remnashop/{__version__} (+https://github.com/snoups/remnashop)"
+                ),
+                "project": settings.project_uuid,
+            },
+        )
+
+    async def handle_create_payment(self, amount: Decimal, details: str) -> PaymentResultDto:
+        settings = self._get_settings()
+        redirect_url = await self._get_bot_redirect_url()
+        payload = {
+            "amount": str(amount),
+            "currency": self.data.currency.value,
+            "order_id": str(uuid4()),
+            "url_return": redirect_url,
+            "url_success": redirect_url,
+            "url_callback": self.config.get_webhook(self.data.type),
+            "description": details[:200],
+            "ttl_seconds": settings.ttl_seconds,
+        }
+        body = orjson.dumps(payload)
+        logger.debug(f"Creating 2328.io payment payload: {payload}")
+
+        try:
+            response = await self._client.post(
+                "/v1/payment",
+                content=body,
+                headers={"sign": self._sign(body)},
+            )
+            response.raise_for_status()
+            data = orjson.loads(response.content)
+            return self._get_payment_data(data)
+        except HTTPStatusError as e:
+            logger.error(
+                "HTTP error creating 2328.io payment. "
+                f"Status: '{e.response.status_code}', Body: {e.response.text}"
+            )
+            raise
+        except (KeyError, ValueError, orjson.JSONDecodeError) as e:
+            logger.error(f"Failed to parse 2328.io response. Error: {e}")
+            raise
+        except Exception as e:
+            logger.exception(f"Unexpected error creating 2328.io payment: {e}")
+            raise
+
+    async def handle_webhook(self, request: Request) -> Union[tuple[UUID, TransactionStatus], None]:
+        payload = await self._get_webhook_data(request)
+        self._verify_webhook(payload)
+
+        payment_id_raw = payload.get("uuid")
+        if not payment_id_raw:
+            raise ValueError("Required field 'uuid' is missing")
+
+        payment_id = UUID(str(payment_id_raw))
+        status = payload.get("payment_status")
+
+        match status:
+            case "paid" | "overpaid":
+                return payment_id, TransactionStatus.COMPLETED
+            case "underpaid" | "cancel" | "aml_lock":
+                return payment_id, TransactionStatus.CANCELED
+            case "pending" | "check" | "underpaid_check":
+                logger.debug(f"2328.io webhook status '{status}' — skipping")
+                return None
+            case _:
+                raise ValueError(f"Unsupported 2328.io payment status: {status}")
+
+    def _get_payment_data(self, data: dict[str, Any]) -> PaymentResultDto:
+        if data.get("state") != 0:
+            raise ValueError(f"2328.io returned unsuccessful state: {data.get('state')}")
+
+        result = data.get("result")
+        if not isinstance(result, dict):
+            raise KeyError("Invalid 2328.io response: missing 'result'")
+
+        payment_id = result.get("uuid")
+        payment_url = result.get("url")
+        if not payment_id or not payment_url:
+            raise KeyError("Invalid 2328.io response: missing payment uuid or url")
+
+        return PaymentResultDto(id=UUID(str(payment_id)), url=str(payment_url))
+
+    def _get_settings(self) -> Pay2328GatewaySettingsDto:
+        settings = self.data.settings
+        if not isinstance(settings, Pay2328GatewaySettingsDto):
+            raise TypeError(
+                f"Invalid settings type: expected {Pay2328GatewaySettingsDto.__name__}, "
+                f"got {type(settings).__name__}"
+            )
+        return settings
+
+    def _sign(self, body: bytes) -> str:
+        settings = self._get_settings()
+        if not settings.api_key:
+            raise ValueError("2328.io API key is not configured")
+
+        encoded = base64.b64encode(body)
+        api_key = settings.api_key.get_secret_value()
+        return hmac.new(api_key.encode(), encoded, hashlib.sha256).hexdigest()
+
+    def _verify_webhook(self, payload: dict[str, Any]) -> None:
+        received_signature = payload.pop("sign", None)
+        if not isinstance(received_signature, str) or not received_signature:
+            raise PermissionError("2328.io webhook signature is missing")
+
+        expected_signature = self._sign(orjson.dumps(payload))
+        if not hmac.compare_digest(received_signature.lower(), expected_signature.lower()):
+            logger.warning("2328.io webhook HMAC signature verification failed")
+            raise PermissionError("2328.io webhook verification failed")

--- a/tests/test_pay_2328_gateway.py
+++ b/tests/test_pay_2328_gateway.py
@@ -1,0 +1,167 @@
+import base64
+import hashlib
+import hmac
+from typing import Any
+from uuid import UUID, uuid4
+
+import orjson
+import pytest
+from pydantic import SecretStr
+from starlette.requests import Request
+
+from src.application.dto.payment_gateway import (
+    Pay2328GatewaySettingsDto,
+    PaymentGatewayDto,
+)
+from src.application.use_cases.gateways.commands.payment import CreateDefaultPaymentGateway
+from src.core.enums import Currency, PaymentGatewayType, TransactionStatus
+from src.infrastructure.payment_gateways.pay_2328 import Pay2328Gateway
+
+
+API_KEY = "test-api-key"
+
+
+def make_gateway() -> Pay2328Gateway:
+    gateway = object.__new__(Pay2328Gateway)
+    gateway.data = PaymentGatewayDto(
+        type=PaymentGatewayType.PAY_2328,
+        currency=Currency.RUB,
+        settings=Pay2328GatewaySettingsDto(
+            project_uuid="00000000-0000-0000-0000-000000000001",
+            api_key=SecretStr(API_KEY),
+        ),
+    )
+    return gateway
+
+
+def make_request(payload: dict[str, Any]) -> Request:
+    body = orjson.dumps(payload)
+    sent = False
+
+    async def receive() -> dict[str, Any]:
+        nonlocal sent
+        if sent:
+            return {"type": "http.disconnect"}
+        sent = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/",
+            "query_string": b"",
+            "headers": [],
+        },
+        receive,
+    )
+
+
+def sign(payload: dict[str, Any]) -> str:
+    encoded = base64.b64encode(orjson.dumps(payload))
+    return hmac.new(API_KEY.encode(), encoded, hashlib.sha256).hexdigest()
+
+
+def test_sign_uses_base64_encoded_compact_json() -> None:
+    gateway = make_gateway()
+    body = orjson.dumps({"amount": "100", "currency": "RUB"})
+
+    expected = hmac.new(
+        API_KEY.encode(),
+        base64.b64encode(body),
+        hashlib.sha256,
+    ).hexdigest()
+
+    assert gateway._sign(body) == expected
+
+
+@pytest.mark.parametrize("status", ["paid", "overpaid"])
+async def test_success_webhook_statuses(status: str) -> None:
+    gateway = make_gateway()
+    payment_id = uuid4()
+    unsigned = {"uuid": str(payment_id), "payment_status": status}
+    request = make_request({**unsigned, "sign": sign(unsigned)})
+
+    result = await gateway.handle_webhook(request)
+
+    assert result == (payment_id, TransactionStatus.COMPLETED)
+
+
+@pytest.mark.parametrize("status", ["pending", "check", "underpaid_check"])
+async def test_pending_webhook_statuses_are_ignored(status: str) -> None:
+    gateway = make_gateway()
+    unsigned = {"uuid": str(uuid4()), "payment_status": status}
+    request = make_request({**unsigned, "sign": sign(unsigned)})
+
+    assert await gateway.handle_webhook(request) is None
+
+
+@pytest.mark.parametrize("status", ["underpaid", "cancel", "aml_lock"])
+async def test_unsuccessful_webhook_statuses_are_canceled(status: str) -> None:
+    gateway = make_gateway()
+    payment_id = uuid4()
+    unsigned = {"uuid": str(payment_id), "payment_status": status}
+    request = make_request({**unsigned, "sign": sign(unsigned)})
+
+    result = await gateway.handle_webhook(request)
+
+    assert result == (payment_id, TransactionStatus.CANCELED)
+
+
+async def test_invalid_webhook_signature_is_rejected() -> None:
+    gateway = make_gateway()
+    request = make_request(
+        {
+            "uuid": str(UUID(int=1)),
+            "payment_status": "paid",
+            "sign": "invalid",
+        }
+    )
+
+    with pytest.raises(PermissionError, match="verification failed"):
+        await gateway.handle_webhook(request)
+
+
+class FakeUnitOfWork:
+    async def __aenter__(self) -> "FakeUnitOfWork":
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def commit(self) -> None:
+        return None
+
+
+class FakePaymentGatewayDao:
+    def __init__(self) -> None:
+        self.created: list[PaymentGatewayDto] = []
+
+    async def get_by_type(self, gateway_type: PaymentGatewayType) -> object | None:
+        if gateway_type == PaymentGatewayType.PAY_2328:
+            return None
+        return object()
+
+    async def create(self, gateway: PaymentGatewayDto) -> PaymentGatewayDto:
+        self.created.append(gateway)
+        return gateway
+
+    async def get_all(self) -> list[PaymentGatewayDto]:
+        return self.created
+
+    async def update(self, gateway: PaymentGatewayDto) -> PaymentGatewayDto:
+        return gateway
+
+
+async def test_default_gateway_bootstrap_creates_typed_2328_settings() -> None:
+    dao = FakePaymentGatewayDao()
+    interactor = CreateDefaultPaymentGateway(FakeUnitOfWork(), dao)  # type: ignore[arg-type]
+
+    await interactor._execute(None, None)  # type: ignore[arg-type]
+
+    assert len(dao.created) == 1
+    gateway = dao.created[0]
+    assert gateway.type == PaymentGatewayType.PAY_2328
+    assert isinstance(gateway.settings, Pay2328GatewaySettingsDto)
+    assert gateway.settings.ttl_seconds == 3600
+    assert gateway.settings.is_configured is False


### PR DESCRIPTION
## Summary

- add 2328.io as a payment gateway
- register typed settings in the default gateway bootstrap, Retort and DI
- add signed create-payment requests and signed webhook verification
- add the PostgreSQL enum migration and Russian gateway label
- add tests for request signing, webhook statuses and default settings creation

## Implementation

- sends compact JSON to `POST /v1/payment`
- signs Base64-encoded request JSON with HMAC-SHA256
- sends the required `project`, `sign` and `User-Agent` headers
- passes `url_callback` for each payment, so no static webhook registration is required
- verifies callbacks by removing `sign` and signing the remaining compact JSON while preserving field order

Status mapping:

- `paid`, `overpaid` → `COMPLETED`
- `pending`, `check`, `underpaid_check` → ignored until a terminal callback
- `underpaid`, `cancel`, `aml_lock` → `CANCELED`

Default settings:

- `project_uuid`
- `api_key`
- `ttl_seconds = 3600`

## Migration

Migration `0041` only extends `payment_gateway_type`.

After migrations, the existing `CreateDefaultPaymentGateway` bootstrap creates the inactive `PAY_2328` row with `Pay2328GatewaySettingsDto`.

This avoids using a newly added PostgreSQL enum value in the same migration transaction and prevents the gateway from being created with `settings = NULL`.

## Validation

- unit tests cover signing and all documented webhook statuses
- unit test verifies that bootstrap creates typed and editable 2328.io settings
- the adapted implementation was validated on Remnashop 0.8.2 in a live deployment for migration, DI registration, ORM-to-DTO conversion and encrypted settings persistence

Closes #116