### PR TITLE
fix(web): allow Telegram auth without verified email for payments and trial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .vscode/
 .code-workspace
 data/*
-tests
 .DS_Store
 traefik
 logs/*

--- a/src/web/endpoints/public/subscription.py
+++ b/src/web/endpoints/public/subscription.py
@@ -48,7 +48,7 @@ from src.core.exceptions import (
     PromocodeNotFoundError,
     TrialNotAvailableError,
 )
-from src.web.purchase_access import assert_web_purchase_email_verified
+from src.web.purchase_access import assert_web_payment_allowed
 from src.web.schemas import (
     DeviceDeleteResponse,
     DeviceResponse,
@@ -91,6 +91,16 @@ def _assert_web_gateway(gateway_type: PaymentGatewayType) -> None:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="TELEGRAM_STARS gateway is not available for web purchase",
         )
+
+
+def _assert_web_purchase_email_verified(user: UserDto) -> None:
+    if user.is_email_verified:
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail="Email must be verified before purchasing or extending a subscription",
+    )
 
 
 async def _get_available_plan_by_code(
@@ -222,7 +232,7 @@ async def activate_promocode_web(
     user: CurrentUser,
     activate_promocode: FromDishka[ActivatePromocode],
 ) -> PromocodeActivateResponse:
-    assert_web_purchase_email_verified(user)
+    _assert_web_purchase_email_verified(user)
     try:
         promo = await activate_promocode(user, ActivatePromocodeDto(code=body.code, user=user))
     except PromocodeNotFoundError as e:
@@ -246,7 +256,7 @@ async def activate_trial_web(
     get_available_trial: FromDishka[GetAvailableTrial],
     activate_trial: FromDishka[ActivateTrialSubscription],
 ) -> TrialActivateResponse:
-    assert_web_purchase_email_verified(user)
+    _assert_web_purchase_email_verified(user)
 
     plan = await get_available_trial.system(user)
     if not plan or not plan.durations:
@@ -318,7 +328,7 @@ async def purchase_trial_web(
     create_payment: FromDishka[CreatePayment],
     process_payment: FromDishka[ProcessPayment],
 ) -> PaymentInitResponse:
-    assert_web_purchase_email_verified(user)
+    assert_web_payment_allowed(user)
     await _validate_gateway_for_web(body.gateway_type, payment_gateway_dao)
 
     plan = await get_available_trial.system(user)
@@ -388,7 +398,7 @@ async def purchase_subscription(
     create_payment: FromDishka[CreatePayment],
     process_payment: FromDishka[ProcessPayment],
 ) -> PaymentInitResponse:
-    assert_web_purchase_email_verified(user)
+    assert_web_payment_allowed(user)
     await _validate_gateway_for_web(body.gateway_type, payment_gateway_dao)
 
     plan = await _get_available_plan_by_code(user, body.plan_code, get_available_plans)
@@ -460,7 +470,7 @@ async def extend_subscription(
     create_payment: FromDishka[CreatePayment],
     process_payment: FromDishka[ProcessPayment],
 ) -> PaymentInitResponse:
-    assert_web_purchase_email_verified(user)
+    assert_web_payment_allowed(user)
     await _validate_gateway_for_web(body.gateway_type, payment_gateway_dao)
 
     current_subscription = await subscription_dao.get_current(user.id)

--- a/src/web/endpoints/public/subscription.py
+++ b/src/web/endpoints/public/subscription.py
@@ -256,7 +256,7 @@ async def activate_trial_web(
     get_available_trial: FromDishka[GetAvailableTrial],
     activate_trial: FromDishka[ActivateTrialSubscription],
 ) -> TrialActivateResponse:
-    _assert_web_purchase_email_verified(user)
+    assert_web_payment_allowed(user)
 
     plan = await get_available_trial.system(user)
     if not plan or not plan.durations:

--- a/src/web/endpoints/public/subscription.py
+++ b/src/web/endpoints/public/subscription.py
@@ -48,6 +48,7 @@ from src.core.exceptions import (
     PromocodeNotFoundError,
     TrialNotAvailableError,
 )
+from src.web.purchase_access import assert_web_purchase_email_verified
 from src.web.schemas import (
     DeviceDeleteResponse,
     DeviceResponse,
@@ -90,16 +91,6 @@ def _assert_web_gateway(gateway_type: PaymentGatewayType) -> None:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="TELEGRAM_STARS gateway is not available for web purchase",
         )
-
-
-def _assert_web_purchase_email_verified(user: UserDto) -> None:
-    if user.is_email_verified:
-        return
-
-    raise HTTPException(
-        status_code=status.HTTP_409_CONFLICT,
-        detail="Email must be verified before purchasing or extending a subscription",
-    )
 
 
 async def _get_available_plan_by_code(
@@ -231,7 +222,7 @@ async def activate_promocode_web(
     user: CurrentUser,
     activate_promocode: FromDishka[ActivatePromocode],
 ) -> PromocodeActivateResponse:
-    _assert_web_purchase_email_verified(user)
+    assert_web_purchase_email_verified(user)
     try:
         promo = await activate_promocode(user, ActivatePromocodeDto(code=body.code, user=user))
     except PromocodeNotFoundError as e:
@@ -255,7 +246,7 @@ async def activate_trial_web(
     get_available_trial: FromDishka[GetAvailableTrial],
     activate_trial: FromDishka[ActivateTrialSubscription],
 ) -> TrialActivateResponse:
-    _assert_web_purchase_email_verified(user)
+    assert_web_purchase_email_verified(user)
 
     plan = await get_available_trial.system(user)
     if not plan or not plan.durations:
@@ -327,7 +318,7 @@ async def purchase_trial_web(
     create_payment: FromDishka[CreatePayment],
     process_payment: FromDishka[ProcessPayment],
 ) -> PaymentInitResponse:
-    _assert_web_purchase_email_verified(user)
+    assert_web_purchase_email_verified(user)
     await _validate_gateway_for_web(body.gateway_type, payment_gateway_dao)
 
     plan = await get_available_trial.system(user)
@@ -397,7 +388,7 @@ async def purchase_subscription(
     create_payment: FromDishka[CreatePayment],
     process_payment: FromDishka[ProcessPayment],
 ) -> PaymentInitResponse:
-    _assert_web_purchase_email_verified(user)
+    assert_web_purchase_email_verified(user)
     await _validate_gateway_for_web(body.gateway_type, payment_gateway_dao)
 
     plan = await _get_available_plan_by_code(user, body.plan_code, get_available_plans)
@@ -469,7 +460,7 @@ async def extend_subscription(
     create_payment: FromDishka[CreatePayment],
     process_payment: FromDishka[ProcessPayment],
 ) -> PaymentInitResponse:
-    _assert_web_purchase_email_verified(user)
+    assert_web_purchase_email_verified(user)
     await _validate_gateway_for_web(body.gateway_type, payment_gateway_dao)
 
     current_subscription = await subscription_dao.get_current(user.id)

--- a/src/web/purchase_access.py
+++ b/src/web/purchase_access.py
@@ -4,7 +4,7 @@ from src.application.dto import UserDto
 from src.core.enums import AuthType
 
 
-def assert_web_purchase_email_verified(user: UserDto) -> None:
+def assert_web_payment_allowed(user: UserDto) -> None:
     if user.auth_type == AuthType.TELEGRAM or user.is_email_verified:
         return
 

--- a/src/web/purchase_access.py
+++ b/src/web/purchase_access.py
@@ -5,6 +5,7 @@ from src.core.enums import AuthType
 
 
 def assert_web_payment_allowed(user: UserDto) -> None:
+    """Allow Telegram-auth subscription actions without weakening email auth."""
     if user.auth_type == AuthType.TELEGRAM or user.is_email_verified:
         return
 

--- a/src/web/purchase_access.py
+++ b/src/web/purchase_access.py
@@ -1,0 +1,14 @@
+from fastapi import HTTPException, status
+
+from src.application.dto import UserDto
+from src.core.enums import AuthType
+
+
+def assert_web_purchase_email_verified(user: UserDto) -> None:
+    if user.auth_type == AuthType.TELEGRAM or user.is_email_verified:
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail="Email must be verified before purchasing or extending a subscription",
+    )

--- a/tests/web/endpoints/public/test_subscription.py
+++ b/tests/web/endpoints/public/test_subscription.py
@@ -3,7 +3,7 @@ from fastapi import HTTPException, status
 
 from src.application.dto import UserDto
 from src.core.enums import AuthType
-from src.web.purchase_access import assert_web_purchase_email_verified
+from src.web.purchase_access import assert_web_payment_allowed
 
 
 def test_telegram_auth_can_purchase_without_verified_email() -> None:
@@ -13,7 +13,7 @@ def test_telegram_auth_can_purchase_without_verified_email() -> None:
         name="Telegram user",
     )
 
-    assert_web_purchase_email_verified(user)
+    assert_web_payment_allowed(user)
 
 
 def test_email_auth_cannot_purchase_without_verified_email() -> None:
@@ -24,7 +24,7 @@ def test_email_auth_cannot_purchase_without_verified_email() -> None:
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        assert_web_purchase_email_verified(user)
+        assert_web_payment_allowed(user)
 
     assert exc_info.value.status_code == status.HTTP_409_CONFLICT
     assert exc_info.value.detail == (
@@ -39,4 +39,4 @@ def test_email_auth_can_purchase_with_verified_email() -> None:
         name="Email user",
     )
 
-    assert_web_purchase_email_verified(user)
+    assert_web_payment_allowed(user)

--- a/tests/web/endpoints/public/test_subscription.py
+++ b/tests/web/endpoints/public/test_subscription.py
@@ -1,0 +1,42 @@
+import pytest
+from fastapi import HTTPException, status
+
+from src.application.dto import UserDto
+from src.core.enums import AuthType
+from src.web.purchase_access import assert_web_purchase_email_verified
+
+
+def test_telegram_auth_can_purchase_without_verified_email() -> None:
+    user = UserDto(
+        auth_type=AuthType.TELEGRAM,
+        is_email_verified=False,
+        name="Telegram user",
+    )
+
+    assert_web_purchase_email_verified(user)
+
+
+def test_email_auth_cannot_purchase_without_verified_email() -> None:
+    user = UserDto(
+        auth_type=AuthType.EMAIL,
+        is_email_verified=False,
+        name="Email user",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        assert_web_purchase_email_verified(user)
+
+    assert exc_info.value.status_code == status.HTTP_409_CONFLICT
+    assert exc_info.value.detail == (
+        "Email must be verified before purchasing or extending a subscription"
+    )
+
+
+def test_email_auth_can_purchase_with_verified_email() -> None:
+    user = UserDto(
+        auth_type=AuthType.EMAIL,
+        is_email_verified=True,
+        name="Email user",
+    )
+
+    assert_web_purchase_email_verified(user)

--- a/tests/web/endpoints/public/test_subscription.py
+++ b/tests/web/endpoints/public/test_subscription.py
@@ -1,3 +1,6 @@
+import ast
+from pathlib import Path
+
 import pytest
 from fastapi import HTTPException, status
 
@@ -40,3 +43,28 @@ def test_email_auth_can_purchase_with_verified_email() -> None:
     )
 
     assert_web_payment_allowed(user)
+
+
+def test_free_trial_endpoint_uses_telegram_aware_access_policy() -> None:
+    endpoint_path = (
+        Path(__file__).resolve().parents[4]
+        / "src"
+        / "web"
+        / "endpoints"
+        / "public"
+        / "subscription.py"
+    )
+    tree = ast.parse(endpoint_path.read_text(encoding="utf-8"))
+    endpoint = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "activate_trial_web"
+    )
+    calls = {
+        node.func.id
+        for node in ast.walk(endpoint)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+
+    assert "assert_web_payment_allowed" in calls
+    assert "_assert_web_purchase_email_verified" not in calls


### PR DESCRIPTION
## Summary

Allow Telegram-authenticated users to use web subscription actions without requiring a verified email, while preserving the verified-email requirement for ordinary email authentication.

Covered actions:
- paid trial purchase;
- new subscription purchase;
- subscription renewal;
- free trial activation.

## Safety

The bypass is limited to AuthType.TELEGRAM. AuthType.EMAIL without verified email continues to receive HTTP 409.

## Tests

Focused access-policy and endpoint contract tests cover Telegram unverified, email unverified, email verified, and the free-trial endpoint guard. Ruff passes.